### PR TITLE
Add basic auth and price match UI

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -5,6 +5,8 @@ import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { MobileOptimizationProvider } from "@/components/mobile-optimization-provider"
+import { AuthProvider } from "@/contexts/auth-context"
+import { ApiKeyProvider } from "@/contexts/api-keys-context"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -51,8 +53,12 @@ export default function RootLayout({
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <MobileOptimizationProvider>
-            {children}
-            <Toaster />
+            <AuthProvider>
+              <ApiKeyProvider>
+                {children}
+                <Toaster />
+              </ApiKeyProvider>
+            </AuthProvider>
           </MobileOptimizationProvider>
         </ThemeProvider>
       </body>

--- a/client/app/login/page.tsx
+++ b/client/app/login/page.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAuth } from "@/contexts/auth-context"
+
+export default function LoginPage() {
+  const { login } = useAuth()
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(email, password)
+      router.push("/")
+    } catch (err) {
+      setError("Invalid credentials")
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-black px-4">
+      <Card className="w-full max-w-md glass-effect border-white/10">
+        <CardHeader>
+          <CardTitle className="text-white text-center">Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email" className="text-white">Email</Label>
+              <Input id="email" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} className="bg-white/5 border-white/10" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-white">Password</Label>
+              <Input id="password" type="password" value={password} onChange={(e)=>setPassword(e.target.value)} className="bg-white/5 border-white/10" />
+            </div>
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+            <Button type="submit" className="w-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] text-black font-semibold">Login</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/client/app/price-match/page.tsx
+++ b/client/app/price-match/page.tsx
@@ -1,0 +1,16 @@
+import { DashboardLayout } from "@/components/dashboard-layout"
+import { PriceMatchModule } from "@/components/price-match-module"
+
+export default function PriceMatchPage(){
+  return (
+    <DashboardLayout>
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-4xl font-bold bg-gradient-to-r from-[#00D4FF] to-[#00FF88] bg-clip-text text-transparent">Price Match</h1>
+          <p className="text-muted-foreground mt-2">Upload a spreadsheet to find matching items</p>
+        </div>
+        <PriceMatchModule />
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/client/app/register/page.tsx
+++ b/client/app/register/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAuth } from "@/contexts/auth-context"
+
+export default function RegisterPage() {
+  const { register } = useAuth()
+  const router = useRouter()
+  const [name,setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await register(name,email,password)
+      router.push("/")
+    } catch (err) {
+      setError("Registration failed")
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-black px-4">
+      <Card className="w-full max-w-md glass-effect border-white/10">
+        <CardHeader>
+          <CardTitle className="text-white text-center">Register</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name" className="text-white">Name</Label>
+              <Input id="name" value={name} onChange={(e)=>setName(e.target.value)} className="bg-white/5 border-white/10" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email" className="text-white">Email</Label>
+              <Input id="email" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} className="bg-white/5 border-white/10" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-white">Password</Label>
+              <Input id="password" type="password" value={password} onChange={(e)=>setPassword(e.target.value)} className="bg-white/5 border-white/10" />
+            </div>
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+            <Button type="submit" className="w-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] text-black font-semibold">Create Account</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { priceMatch } from "@/lib/api"
+import { useApiKeys } from "@/contexts/api-keys-context"
+
+interface MatchResult {
+  inputDescription: string
+  quantity: number
+  matches: { description: string; unitRate: number; confidence: number }[]
+}
+
+export function PriceMatchModule() {
+  const { openaiKey, cohereKey, geminiKey } = useApiKeys()
+  const [file, setFile] = useState<File | null>(null)
+  const [results, setResults] = useState<MatchResult[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setFile(e.target.files[0])
+    }
+  }
+
+  const runMatch = async () => {
+    if (!file) return
+    setLoading(true)
+    try {
+      const data = await priceMatch(file, { openaiKey, cohereKey, geminiKey })
+      setResults(data)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Card className="glass-effect border-white/10">
+      <CardHeader>
+        <CardTitle className="text-white">Price Match</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Input type="file" accept=".xlsx,.xls" onChange={handleFile} />
+        <Button onClick={runMatch} disabled={!file || loading} className="bg-gradient-to-r from-[#00D4FF] to-[#00FF88] text-black font-semibold">
+          {loading ? "Matching..." : "Start Matching"}
+        </Button>
+        {results && (
+          <div className="overflow-auto max-h-96">
+            <table className="w-full text-sm text-left mt-4">
+              <thead>
+                <tr className="text-white">
+                  <th className="px-2 py-1">Description</th>
+                  <th className="px-2 py-1">Qty</th>
+                  <th className="px-2 py-1">Match</th>
+                  <th className="px-2 py-1">Rate</th>
+                  <th className="px-2 py-1">Conf.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.map((r, idx) => (
+                  <tr key={idx} className="text-gray-300 border-t border-white/10">
+                    <td className="px-2 py-1">{r.inputDescription}</td>
+                    <td className="px-2 py-1">{r.quantity}</td>
+                    <td className="px-2 py-1">{r.matches[0]?.description}</td>
+                    <td className="px-2 py-1">{r.matches[0]?.unitRate}</td>
+                    <td className="px-2 py-1">{r.matches[0]?.confidence}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/client/components/settings-panel.tsx
+++ b/client/components/settings-panel.tsx
@@ -8,7 +8,8 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { User, Bell, Shield, Palette, Save } from "lucide-react"
+import { User, Bell, Shield, Palette, Key, Save } from "lucide-react"
+import { useApiKeys } from "@/contexts/api-keys-context"
 
 export function SettingsPanel() {
   const [notifications, setNotifications] = useState({
@@ -16,6 +17,7 @@ export function SettingsPanel() {
     push: false,
     sms: true,
   })
+  const { openaiKey, cohereKey, geminiKey, setKeys } = useApiKeys()
 
   return (
     <div className="max-w-4xl">
@@ -48,6 +50,13 @@ export function SettingsPanel() {
           >
             <Palette className="h-4 w-4 mr-2" />
             Appearance
+          </TabsTrigger>
+          <TabsTrigger
+            value="apikeys"
+            className="data-[state=active]:bg-[#00D4FF]/20 data-[state=active]:text-[#00D4FF]"
+          >
+            <Key className="h-4 w-4 mr-2" />
+            API Keys
           </TabsTrigger>
         </TabsList>
 
@@ -222,6 +231,28 @@ export function SettingsPanel() {
                   <div className="w-8 h-8 rounded-full bg-[#00FF88] cursor-pointer border-2 border-transparent"></div>
                   <div className="w-8 h-8 rounded-full bg-[#FF6B35] cursor-pointer border-2 border-transparent"></div>
                 </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="apikeys" className="space-y-6">
+          <Card className="glass-effect border-white/10">
+            <CardHeader>
+              <CardTitle className="text-white">API Keys</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="openai" className="text-white">OpenAI Key</Label>
+                <Input id="openai" value={openaiKey} onChange={e=>setKeys({openaiKey:e.target.value})} className="bg-white/5 border-white/10" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cohere" className="text-white">Cohere Key</Label>
+                <Input id="cohere" value={cohereKey} onChange={e=>setKeys({cohereKey:e.target.value})} className="bg-white/5 border-white/10" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="gemini" className="text-white">Gemini Key</Label>
+                <Input id="gemini" value={geminiKey} onChange={e=>setKeys({geminiKey:e.target.value})} className="bg-white/5 border-white/10" />
               </div>
             </CardContent>
           </Card>

--- a/client/components/sidebar.tsx
+++ b/client/components/sidebar.tsx
@@ -18,6 +18,7 @@ const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Quotations", href: "/quotations", icon: FileText },
   { name: "Upload", href: "/upload", icon: Upload },
+  { name: "Price Match", href: "/price-match", icon: FileText },
   { name: "Clients", href: "/clients", icon: Users },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Settings", href: "/settings", icon: Settings },

--- a/client/contexts/api-keys-context.tsx
+++ b/client/contexts/api-keys-context.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import React, { createContext, useContext, useState, useEffect } from "react"
+
+interface ApiKeyContextType {
+  openaiKey: string
+  cohereKey: string
+  geminiKey: string
+  setKeys: (keys: Partial<{openaiKey:string;cohereKey:string;geminiKey:string}>) => void
+}
+
+const ApiKeyContext = createContext<ApiKeyContextType>({
+  openaiKey: "",
+  cohereKey: "",
+  geminiKey: "",
+  setKeys: () => {}
+})
+
+export function ApiKeyProvider({children}:{children:React.ReactNode}){
+  const [openaiKey,setOpenai] = useState("")
+  const [cohereKey,setCohere] = useState("")
+  const [geminiKey,setGemini] = useState("")
+
+  useEffect(() => {
+    const stored = localStorage.getItem("apiKeys")
+    if(stored){
+      const k = JSON.parse(stored)
+      setOpenai(k.openaiKey||"")
+      setCohere(k.cohereKey||"")
+      setGemini(k.geminiKey||"")
+    }
+  },[])
+
+  const setKeys = (keys: Partial<{openaiKey:string;cohereKey:string;geminiKey:string}>) => {
+    if(keys.openaiKey!==undefined) setOpenai(keys.openaiKey)
+    if(keys.cohereKey!==undefined) setCohere(keys.cohereKey)
+    if(keys.geminiKey!==undefined) setGemini(keys.geminiKey)
+    const all = {
+      openaiKey: keys.openaiKey ?? openaiKey,
+      cohereKey: keys.cohereKey ?? cohereKey,
+      geminiKey: keys.geminiKey ?? geminiKey
+    }
+    localStorage.setItem("apiKeys", JSON.stringify(all))
+  }
+
+  return (
+    <ApiKeyContext.Provider value={{openaiKey,cohereKey,geminiKey,setKeys}}>
+      {children}
+    </ApiKeyContext.Provider>
+  )
+}
+
+export const useApiKeys = () => useContext(ApiKeyContext)

--- a/client/contexts/auth-context.tsx
+++ b/client/contexts/auth-context.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import React, { createContext, useContext, useState, useEffect } from "react"
+import { loginUser, registerUser } from "@/lib/api"
+
+interface User {
+  id: string
+  name: string
+}
+
+interface AuthContextType {
+  user: User | null
+  token: string | null
+  login: (email: string, password: string) => Promise<void>
+  register: (name: string, email: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  token: null,
+  login: async () => {},
+  register: async () => {},
+  logout: () => {}
+})
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem("auth")
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      setUser(parsed.user)
+      setToken(parsed.token)
+    }
+  }, [])
+
+  const login = async (email: string, password: string) => {
+    const res = await loginUser(email, password)
+    setUser(res.user)
+    setToken(res.token)
+    localStorage.setItem("auth", JSON.stringify(res))
+  }
+
+  const register = async (name: string, email: string, password: string) => {
+    const res = await registerUser(name, email, password)
+    setUser(res.user)
+    setToken(res.token)
+    localStorage.setItem("auth", JSON.stringify(res))
+  }
+
+  const logout = () => {
+    setUser(null)
+    setToken(null)
+    localStorage.removeItem("auth")
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -16,3 +16,40 @@ export async function getProjects(): Promise<Project[]> {
   }
   return res.json()
 }
+
+export async function loginUser(email: string, password: string) {
+  const res = await fetch(`${base}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  })
+  if (!res.ok) {
+    throw new Error('Login failed')
+  }
+  return res.json()
+}
+
+export async function registerUser(name: string, email: string, password: string) {
+  const res = await fetch(`${base}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, password })
+  })
+  if (!res.ok) {
+    throw new Error('Registration failed')
+  }
+  return res.json()
+}
+
+export async function priceMatch(file: File, keys: {openaiKey?:string; cohereKey?:string; geminiKey?:string}) {
+  const form = new FormData()
+  form.append('file', file)
+  if (keys.openaiKey) form.append('openaiKey', keys.openaiKey)
+  if (keys.cohereKey) form.append('cohereKey', keys.cohereKey)
+  if (keys.geminiKey) form.append('geminiKey', keys.geminiKey)
+  const res = await fetch(`${base}/api/match`, { method: 'POST', body: form })
+  if (!res.ok) {
+    throw new Error('Price match failed')
+  }
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- introduce authentication and API key contexts
- add login and register pages
- add price match module and page
- extend settings with API key tab
- connect backend API calls

## Testing
- `npm test --prefix backend` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_b_6848071947ac83259e502890289694d0