### PR TITLE
Add user profile and password update

### DIFF
--- a/client/components/settings-panel.tsx
+++ b/client/components/settings-panel.tsx
@@ -10,6 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { User, Bell, Shield, Palette, Key, Save } from "lucide-react"
 import { useApiKeys } from "@/contexts/api-keys-context"
+import { useAuth } from "@/contexts/auth-context"
 
 export function SettingsPanel() {
   const [notifications, setNotifications] = useState({
@@ -18,6 +19,23 @@ export function SettingsPanel() {
     sms: true,
   })
   const { openaiKey, cohereKey, geminiKey, setKeys } = useApiKeys()
+  const { user, updateName, changePassword } = useAuth()
+  const [name, setName] = useState(user?.name ?? '')
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  const handleSaveProfile = async () => {
+    await updateName(name)
+  }
+
+  const handleChangePassword = async () => {
+    if (newPassword !== confirmPassword) return
+    await changePassword(currentPassword, newPassword)
+    setCurrentPassword('')
+    setNewPassword('')
+    setConfirmPassword('')
+  }
 
   return (
     <div className="max-w-4xl">
@@ -66,55 +84,19 @@ export function SettingsPanel() {
               <CardTitle className="text-white">Profile Information</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="firstName" className="text-white">
-                    First Name
-                  </Label>
-                  <Input
-                    id="firstName"
-                    defaultValue="John"
-                    className="bg-white/5 border-white/10 focus:border-[#00D4FF] focus:ring-[#00D4FF]/20"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="lastName" className="text-white">
-                    Last Name
-                  </Label>
-                  <Input
-                    id="lastName"
-                    defaultValue="Engineer"
-                    className="bg-white/5 border-white/10 focus:border-[#00D4FF] focus:ring-[#00D4FF]/20"
-                  />
-                </div>
-              </div>
               <div className="space-y-2">
-                <Label htmlFor="email" className="text-white">
-                  Email
-                </Label>
+                <Label htmlFor="name" className="text-white">Name</Label>
                 <Input
-                  id="email"
-                  type="email"
-                  defaultValue="john.engineer@company.com"
-                  className="bg-white/5 border-white/10 focus:border-[#00D4FF] focus:ring-[#00D4FF]/20"
+                  id="name"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  className="bg-white/5 border-white/10"
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="role" className="text-white">
-                  Role
-                </Label>
-                <Select defaultValue="senior">
-                  <SelectTrigger className="bg-white/5 border-white/10">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent className="glass-effect border-white/10">
-                    <SelectItem value="senior">Senior Engineer</SelectItem>
-                    <SelectItem value="lead">Lead Engineer</SelectItem>
-                    <SelectItem value="manager">Project Manager</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <Button className="bg-gradient-to-r from-[#00D4FF] to-[#00FF88] hover:from-[#00D4FF]/80 hover:to-[#00FF88]/80 text-black font-semibold ripple">
+              <Button
+                onClick={handleSaveProfile}
+                className="bg-gradient-to-r from-[#00D4FF] to-[#00FF88] hover:from-[#00D4FF]/80 hover:to-[#00FF88]/80 text-black font-semibold ripple"
+              >
                 <Save className="h-4 w-4 mr-2" />
                 Save Changes
               </Button>
@@ -175,6 +157,8 @@ export function SettingsPanel() {
                 <Input
                   id="currentPassword"
                   type="password"
+                  value={currentPassword}
+                  onChange={e => setCurrentPassword(e.target.value)}
                   className="bg-white/5 border-white/10 focus:border-[#00D4FF] focus:ring-[#00D4FF]/20"
                 />
               </div>
@@ -185,6 +169,8 @@ export function SettingsPanel() {
                 <Input
                   id="newPassword"
                   type="password"
+                  value={newPassword}
+                  onChange={e => setNewPassword(e.target.value)}
                   className="bg-white/5 border-white/10 focus:border-[#00D4FF] focus:ring-[#00D4FF]/20"
                 />
               </div>
@@ -195,10 +181,15 @@ export function SettingsPanel() {
                 <Input
                   id="confirmPassword"
                   type="password"
+                  value={confirmPassword}
+                  onChange={e => setConfirmPassword(e.target.value)}
                   className="bg-white/5 border-white/10 focus:border-[#00D4FF] focus:ring-[#00D4FF]/20"
                 />
               </div>
-              <Button className="bg-gradient-to-r from-[#00D4FF] to-[#00FF88] hover:from-[#00D4FF]/80 hover:to-[#00FF88]/80 text-black font-semibold ripple">
+              <Button
+                onClick={handleChangePassword}
+                className="bg-gradient-to-r from-[#00D4FF] to-[#00FF88] hover:from-[#00D4FF]/80 hover:to-[#00FF88]/80 text-black font-semibold ripple"
+              >
                 Update Password
               </Button>
             </CardContent>

--- a/client/components/sidebar.tsx
+++ b/client/components/sidebar.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useEffect, useState } from "react"
 import { useMobileOptimization } from "@/components/mobile-optimization-provider"
+import { UserProfile } from "@/components/user/user-profile"
 
 interface SidebarProps {
   collapsed: boolean
@@ -151,13 +152,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
 
             {/* User Profile */}
             <div className="border-t border-white/10 p-4 safe-bottom">
-              <div className="flex items-center space-x-3">
-                <div className="h-8 w-8 rounded-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] flex-shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-white truncate">John Engineer</p>
-                  <p className="text-xs text-gray-400 truncate">Senior Engineer</p>
-                </div>
-              </div>
+              <UserProfile collapsed={false} />
             </div>
           </div>
         </div>
@@ -238,13 +233,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
         {/* User Profile */}
         {!collapsed && (
           <div className="border-t border-white/10 p-4">
-            <div className="flex items-center space-x-3">
-              <div className="h-8 w-8 rounded-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88]" />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-white truncate">John Engineer</p>
-                <p className="text-xs text-gray-400 truncate">Senior Engineer</p>
-              </div>
-            </div>
+            <UserProfile collapsed={collapsed} />
           </div>
         )}
       </div>

--- a/client/components/user/user-profile.tsx
+++ b/client/components/user/user-profile.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react"
+import { useAuth } from "@/contexts/auth-context"
 
 interface UserProfileProps {
   collapsed: boolean
@@ -9,12 +10,13 @@ export const UserProfile = memo(function UserProfile({ collapsed }: UserProfileP
     return null
   }
 
+  const { user } = useAuth()
+
   return (
     <div className="flex items-center space-x-3">
       <div className="h-8 w-8 rounded-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] flex-shrink-0" />
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-white truncate">John Engineer</p>
-        <p className="text-xs text-gray-400 truncate">Senior Engineer</p>
+        <p className="text-sm font-medium text-white truncate">{user?.name ?? 'Guest'}</p>
       </div>
     </div>
   )

--- a/client/contexts/auth-context.tsx
+++ b/client/contexts/auth-context.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { createContext, useContext, useState, useEffect } from "react"
-import { loginUser, registerUser } from "@/lib/api"
+import { loginUser, registerUser, updateProfile, changePassword } from "@/lib/api"
 
 interface User {
   id: string
@@ -13,6 +13,8 @@ interface AuthContextType {
   token: string | null
   login: (email: string, password: string) => Promise<void>
   register: (name: string, email: string, password: string) => Promise<void>
+  updateName: (name: string) => Promise<void>
+  changePassword: (current: string, password: string) => Promise<void>
   logout: () => void
 }
 
@@ -21,6 +23,8 @@ const AuthContext = createContext<AuthContextType>({
   token: null,
   login: async () => {},
   register: async () => {},
+  updateName: async () => {},
+  changePassword: async () => {},
   logout: () => {}
 })
 
@@ -51,6 +55,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem("auth", JSON.stringify(res))
   }
 
+  const updateName = async (name: string) => {
+    if (!token) return
+    const res = await updateProfile(name, token)
+    setUser(res.user)
+    setToken(res.token)
+    localStorage.setItem("auth", JSON.stringify(res))
+  }
+
+  const changePasswordFn = async (current: string, password: string) => {
+    if (!token) return
+    await changePassword(current, password, token)
+  }
+
   const logout = () => {
     setUser(null)
     setToken(null)
@@ -58,7 +75,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, token, login, register, logout }}>
+    <AuthContext.Provider value={{ user, token, login, register, updateName, changePassword: changePasswordFn, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -53,3 +53,29 @@ export async function priceMatch(file: File, keys: {openaiKey?:string; cohereKey
   }
   return res.json()
 }
+
+export async function updateProfile(name: string, token: string) {
+  const res = await fetch(`${base}/api/auth/profile`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name }),
+  })
+  if (!res.ok) throw new Error('Update failed')
+  return res.json()
+}
+
+export async function changePassword(currentPassword: string, newPassword: string, token: string) {
+  const res = await fetch(`${base}/api/auth/password`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ currentPassword, newPassword }),
+  })
+  if (!res.ok) throw new Error('Password update failed')
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- allow updating password and profile name via new backend routes
- show logged in user's name in the sidebar
- save API keys and user info in settings panel
- add functions to auth context and API helpers
- simplify profile settings form

## Testing
- `npm test --prefix backend` *(fails: `ERR_MODULE_NOT_FOUND`)*

------
https://chatgpt.com/codex/tasks/task_b_684815d4074483258a24e17a05bb502d