### PR TITLE
Add multi-engine price match options

### DIFF
--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -4,19 +4,25 @@ import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { priceMatch } from "@/lib/api"
+import { priceMatch, searchPriceItems, PriceItem } from "@/lib/api"
 import { useApiKeys } from "@/contexts/api-keys-context"
+import { SearchInput } from "@/components/ui/search-input"
 
 interface MatchResult {
   inputDescription: string
   quantity: number
-  matches: { description: string; unitRate: number; confidence: number }[]
+  matches: { description: string; unitRate: number; confidence: number; engine?: string; code?: string; unit?: string }[]
+}
+
+interface Row extends MatchResult {
+  selected: number | 'manual'
+  searchResults: PriceItem[]
 }
 
 export function PriceMatchModule() {
   const { openaiKey, cohereKey, geminiKey } = useApiKeys()
   const [file, setFile] = useState<File | null>(null)
-  const [results, setResults] = useState<MatchResult[] | null>(null)
+  const [results, setResults] = useState<Row[] | null>(null)
   const [loading, setLoading] = useState(false)
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
@@ -29,12 +35,58 @@ export function PriceMatchModule() {
     setLoading(true)
     try {
       const data = await priceMatch(file, { openaiKey, cohereKey, geminiKey })
-      setResults(data)
+      const rows: Row[] = data.map((r: MatchResult) => ({
+        ...r,
+        selected: r.matches.length ? 0 : 'manual',
+        searchResults: []
+      }))
+      setResults(rows)
     } catch (err) {
       console.error(err)
     } finally {
       setLoading(false)
     }
+  }
+
+  const updateRow = (index: number, updater: (r: Row) => Row) => {
+    if (!results) return
+    setResults(results.map((r, i) => (i === index ? updater({ ...r }) : r)))
+  }
+
+  const handleSelect = (index: number, value: string) => {
+    updateRow(index, r => ({ ...r, selected: value === 'manual' ? 'manual' : parseInt(value, 10) }))
+  }
+
+  const handleSearch = async (index: number, q: string) => {
+    if (!q) {
+      updateRow(index, r => ({ ...r, searchResults: [] }))
+      return
+    }
+    try {
+      const items = await searchPriceItems(q)
+      updateRow(index, r => ({ ...r, searchResults: items }))
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const chooseManual = (rowIndex: number, item: PriceItem) => {
+    updateRow(rowIndex, r => {
+      const match = {
+        engine: 'manual',
+        code: item.code,
+        description: item.description,
+        unit: item.unit,
+        unitRate: item.rate ?? 0,
+        confidence: 1
+      }
+      return {
+        ...r,
+        matches: [...r.matches, match],
+        selected: r.matches.length,
+        searchResults: []
+      }
+    })
   }
 
   return (
@@ -60,15 +112,49 @@ export function PriceMatchModule() {
                 </tr>
               </thead>
               <tbody>
-                {results.map((r, idx) => (
-                  <tr key={idx} className="text-gray-300 border-t border-white/10">
-                    <td className="px-2 py-1">{r.inputDescription}</td>
-                    <td className="px-2 py-1">{r.quantity}</td>
-                    <td className="px-2 py-1">{r.matches[0]?.description}</td>
-                    <td className="px-2 py-1">{r.matches[0]?.unitRate}</td>
-                    <td className="px-2 py-1">{r.matches[0]?.confidence}</td>
-                  </tr>
-                ))}
+                {results.map((r, idx) => {
+                  const sel = typeof r.selected === 'number' ? r.matches[r.selected] : null
+                  return (
+                    <tr key={idx} className="text-gray-300 border-t border-white/10 align-top">
+                      <td className="px-2 py-1 w-48">{r.inputDescription}</td>
+                      <td className="px-2 py-1">{r.quantity}</td>
+                      <td className="px-2 py-1">
+                        <select
+                          className="bg-white/5 border-white/20 text-white text-xs"
+                          value={typeof r.selected === 'number' ? String(r.selected) : 'manual'}
+                          onChange={e => handleSelect(idx, e.target.value)}
+                        >
+                          {r.matches.map((m, i) => (
+                            <option key={i} value={i}>
+                              {m.description}
+                            </option>
+                          ))}
+                          <option value="manual">Manual search...</option>
+                        </select>
+                        {r.selected === 'manual' && (
+                          <div className="mt-1 relative">
+                            <SearchInput placeholder="Search prices" onChange={q => handleSearch(idx, q)} />
+                            {r.searchResults.length > 0 && (
+                              <ul className="absolute z-10 bg-black border border-white/20 max-h-40 overflow-auto w-64">
+                                {r.searchResults.map(item => (
+                                  <li
+                                    key={item._id || item.code}
+                                    className="px-2 py-1 hover:bg-white/10 cursor-pointer"
+                                    onClick={() => chooseManual(idx, item)}
+                                  >
+                                    {item.description}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-2 py-1">{sel?.unitRate ?? ''}</td>
+                      <td className="px-2 py-1">{sel?.confidence ?? ''}</td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -79,3 +79,18 @@ export async function changePassword(currentPassword: string, newPassword: strin
   if (!res.ok) throw new Error('Password update failed')
   return res.json()
 }
+
+export interface PriceItem {
+  _id?: string
+  code?: string
+  description: string
+  unit?: string
+  rate?: number
+}
+
+export async function searchPriceItems(query: string): Promise<PriceItem[]> {
+  const url = `${base}/api/prices/search?q=${encodeURIComponent(query)}`
+  const res = await fetch(url)
+  if (!res.ok) throw new Error('Search failed')
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- add searchPriceItems helper to frontend API
- expand price match module to choose between OpenAI, Cohere or manual matches

## Testing
- `npm test --prefix backend` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_b_68481bfe39188325acebd9837726909d