### PR TITLE
Improve quotation workflow

### DIFF
--- a/client/components/quotation-grid.tsx
+++ b/client/components/quotation-grid.tsx
@@ -9,8 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Eye, Edit, Download, Filter, Search } from "lucide-react"
 import Link from "next/link"
 import { useMobileOptimization } from "@/components/mobile-optimization-provider"
-import { cn } from "@/lib/utils"
-import { getProjects, type Project } from "@/lib/api"
+import { cn, formatCurrency, formatDate } from "@/lib/utils"
+import { loadQuotations } from "@/lib/quotation-store"
 
 interface Quotation {
   id: string
@@ -30,22 +30,18 @@ export function QuotationGrid() {
   const [visibleQuotations, setVisibleQuotations] = useState<Quotation[]>([])
   const [isLoading, setIsLoading] = useState(false)
 
- useEffect(() => {
-    getProjects()
-      .then((projects) => {
-        const mapped = projects.map((p: Project) => ({
-          id: p.id,
-          client: p.client,
-          project: p.type,
-          value: p.value ? `$${p.value.toLocaleString()}` : "$0",
-          status: p.status.toLowerCase(),
-          date: p.due ? new Date(p.due).toISOString().split("T")[0] : "",
-          items: 0,
-        }))
-        setQuotations(mapped)
-        setVisibleQuotations(mapped)
-      })
-      .catch((err) => console.error(err))
+  useEffect(() => {
+    const stored = loadQuotations().map(q => ({
+      id: q.id,
+      client: q.client,
+      project: q.project,
+      value: formatCurrency(q.value),
+      status: q.status,
+      date: formatDate(q.date),
+      items: q.items.length
+    }))
+    setQuotations(stored)
+    setVisibleQuotations(stored)
   }, [])
 
   // Debounced search function

--- a/client/components/quotations/editable-table.tsx
+++ b/client/components/quotations/editable-table.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, memo } from "react"
+import { useState, useEffect, memo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -9,6 +9,8 @@ import { Edit, Save, X, Plus } from "lucide-react"
 
 interface EditableTableProps {
   isEditing: boolean
+  initialItems?: TableItem[]
+  onItemsChange?: (items: TableItem[]) => void
 }
 
 interface TableItem {
@@ -28,9 +30,14 @@ const mockItems: TableItem[] = [
   { id: 5, description: "Interior Finishing", quantity: 2500, unit: "m²", unitPrice: 150, total: 375000 },
 ]
 
-export const EditableTable = memo(function EditableTable({ isEditing }: EditableTableProps) {
-  const [items, setItems] = useState<TableItem[]>(mockItems)
+export const EditableTable = memo(function EditableTable({ isEditing, initialItems, onItemsChange }: EditableTableProps) {
+  const [items, setItems] = useState<TableItem[]>(initialItems ?? mockItems)
   const [editingRow, setEditingRow] = useState<number | null>(null)
+
+  // notify parent when items change
+  useEffect(() => {
+    onItemsChange?.(items)
+  }, [items, onItemsChange])
 
   const handleEdit = (id: number) => {
     setEditingRow(id)
@@ -38,12 +45,12 @@ export const EditableTable = memo(function EditableTable({ isEditing }: Editable
 
   const handleSave = (id: number) => {
     setEditingRow(null)
-    // Save logic here
+    onItemsChange?.(items)
   }
 
   const handleCancel = () => {
     setEditingRow(null)
-    // Reset changes logic here
+    onItemsChange?.(items)
   }
 
   const addNewRow = () => {
@@ -57,6 +64,7 @@ export const EditableTable = memo(function EditableTable({ isEditing }: Editable
     }
     setItems([...items, newItem])
     setEditingRow(newItem.id)
+    onItemsChange?.([...items, newItem])
   }
 
   return (

--- a/client/lib/quotation-store.ts
+++ b/client/lib/quotation-store.ts
@@ -1,0 +1,44 @@
+export interface QuotationItem {
+  id: number
+  description: string
+  quantity: number
+  unit: string
+  unitPrice: number
+  total: number
+}
+
+export interface Quotation {
+  id: string
+  client: string
+  project: string
+  value: number
+  status: string
+  date: string
+  items: QuotationItem[]
+}
+
+const KEY = 'quotations'
+
+export function loadQuotations(): Quotation[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? JSON.parse(raw) as Quotation[] : []
+  } catch {
+    return []
+  }
+}
+
+export function saveQuotation(q: Quotation) {
+  if (typeof localStorage === 'undefined') return
+  const all = loadQuotations()
+  const idx = all.findIndex(i => i.id === q.id)
+  if (idx >= 0) all[idx] = q
+  else all.push(q)
+  localStorage.setItem(KEY, JSON.stringify(all))
+}
+
+export function getQuotation(id: string): Quotation | undefined {
+  return loadQuotations().find(q => q.id === id)
+}
+


### PR DESCRIPTION
## Summary
- show unit in separate column in price match table and add grand total
- store matched quote data locally so it can be edited later
- display saved quotations in the grid
- load and edit stored quotation details

## Testing
- `npm test --prefix backend` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_b_684828b30f1c832585c3cf90c817fc72