### PR TITLE
Add per-user API key save & guests field

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -7,6 +7,7 @@ const userSchema = new mongoose.Schema(
     name:     { type: String, required: true },
     email:    { type: String, required: true, unique: true, index: true },
     password: { type: String, required: true },
+    guests:  { type: Number, required: true },
     /** NEW — set to true once an admin approves the account */
     authorized: { type: Boolean, default: false },
   },

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -29,10 +29,10 @@ function safeParseBody(req) {
 router.post('/register', async (req, res) => {
   try {
     const body = safeParseBody(req);
-    const { name, email, password } = body;
+    const { name, email, password, guests } = body;
 
-    if (!name || !email || !password) {
-      console.warn('[Register] Missing fields', { name, email, password });
+    if (!name || !email || !password || guests === undefined) {
+      console.warn('[Register] Missing fields', { name, email, password, guests });
       return res.status(400).json({ message: 'Missing required fields' });
     }
 
@@ -43,11 +43,11 @@ router.post('/register', async (req, res) => {
         return res.status(400).json({ message: 'Email already in use' });
       }
 
-      const user = await User.create({ name, email, password });
-      const token = signToken({ id: user._id, name: user.name });
+      const user = await User.create({ name, email, password, guests });
+      const token = signToken({ id: user._id, name: user.name, guests: user.guests });
 
       console.log('[Register] MongoDB user created:', user._id);
-      return res.json({ token, user: { id: user._id, name: user.name } });
+      return res.json({ token, user: { id: user._id, name: user.name, guests: user.guests } });
     }
 
     if (sampleUsers.find(u => u.email === email)) {
@@ -56,12 +56,12 @@ router.post('/register', async (req, res) => {
     }
 
     const hash = await bcrypt.hash(password, 10);
-    const user = { id: nanoid(), name, email, password: hash };
+    const user = { id: nanoid(), name, email, password: hash, guests };
     sampleUsers.push(user);
-    const token = signToken({ id: user.id, name: user.name });
+    const token = signToken({ id: user.id, name: user.name, guests });
 
     console.log('[Register] Sample user added:', user.id);
-    return res.json({ token, user: { id: user.id, name: user.name } });
+    return res.json({ token, user: { id: user.id, name: user.name, guests } });
 
   } catch (err) {
     console.error('[Register] Error:', err);
@@ -99,10 +99,10 @@ router.post('/login', async (req, res) => {
     }
 
     const id = user._id || user.id;
-    const token = signToken({ id, name: user.name });
+    const token = signToken({ id, name: user.name, guests: user.guests });
 
     console.log('[Login] Success:', id);
-    return res.json({ token, user: { id, name: user.name } });
+    return res.json({ token, user: { id, name: user.name, guests: user.guests } });
 
   } catch (err) {
     console.error('[Login] Error:', err);

--- a/backend/src/sampleUsers.js
+++ b/backend/src/sampleUsers.js
@@ -5,6 +5,7 @@ export default [
     email: 'alice@example.com',
     // password: password123
     password: '$2b$10$vEtfjjKOjVbAb25/vQoLG.q0ALzfo7kFf5wAW/cc/NPZMpbGXk3n6',
+    guests: 1,
   },
   {
     id: 'U002',
@@ -12,6 +13,7 @@ export default [
     email: 'bob@example.com',
     // password: secret456
     password: '$2b$10$UEbBeRopzGVW/FfewliPP.5QmBibZ1jYG01omC.auzicQn931ovfG',
+    guests: 2,
   },
   {
     id: 'U003',
@@ -19,5 +21,6 @@ export default [
     email: 'cara@example.com',
     // password: admin
     password: '$2b$10$nMU8jle1WZOq3CgKgmmkI.NnI4J4CGxh/XKqTeoNCy5E3Ea31oszi',
+    guests: 3,
   },
 ];

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,18 +1,14 @@
 import { DashboardLayout } from "@/components/dashboard-layout"
-import { QuotationGrid } from "@/components/quotation-grid"
-
-export default function QuotationsPage() {
+export default function HomePage() {
   return (
     <DashboardLayout>
       <div className="space-y-8">
         <div>
           <h1 className="text-4xl font-bold bg-gradient-to-r from-[#00D4FF] to-[#00FF88] bg-clip-text text-transparent">
-            All Quotations
+            Dashboard
           </h1>
-          <p className="text-muted-foreground mt-2">View and manage all your construction quotations</p>
+          <p className="text-muted-foreground mt-2">Welcome to the MJD platform</p>
         </div>
-
-        <QuotationGrid />
       </div>
     </DashboardLayout>
   )

--- a/client/app/register/page.tsx
+++ b/client/app/register/page.tsx
@@ -14,12 +14,13 @@ export default function RegisterPage() {
   const [name,setName] = useState("")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [guests, setGuests] = useState(0)
   const [error, setError] = useState("")
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      await register(name,email,password)
+      await register(name,email,password,guests)
       router.push("/")
     } catch (err) {
       setError("Registration failed")
@@ -45,6 +46,10 @@ export default function RegisterPage() {
             <div className="space-y-2">
               <Label htmlFor="password" className="text-white">Password</Label>
               <Input id="password" type="password" value={password} onChange={(e)=>setPassword(e.target.value)} className="bg-white/5 border-white/10" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="guests" className="text-white">Number of Guests</Label>
+              <Input id="guests" type="number" min="0" value={guests} onChange={e=>setGuests(parseInt(e.target.value,10)||0)} className="bg-white/5 border-white/10" />
             </div>
             {error && <p className="text-red-500 text-sm">{error}</p>}
             <Button type="submit" className="w-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] text-black font-semibold">Create Account</Button>

--- a/client/components/bottom-nav.tsx
+++ b/client/components/bottom-nav.tsx
@@ -2,14 +2,12 @@
 
 import { usePathname } from "next/navigation"
 import Link from "next/link"
-import { LayoutDashboard, FileText, Upload, Users, Settings } from "lucide-react"
+import { LayoutDashboard, Users, Settings } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useMobileOptimization } from "@/components/mobile-optimization-provider"
 
 const navItems = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
-  { name: "Quotations", href: "/quotations", icon: FileText },
-  { name: "Upload", href: "/upload", icon: Upload },
   { name: "Clients", href: "/clients", icon: Users },
   { name: "Settings", href: "/settings", icon: Settings },
 ]

--- a/client/components/settings-panel.tsx
+++ b/client/components/settings-panel.tsx
@@ -18,7 +18,7 @@ export function SettingsPanel() {
     push: false,
     sms: true,
   })
-  const { openaiKey, cohereKey, geminiKey, setKeys } = useApiKeys()
+  const { openaiKey, cohereKey, geminiKey, setKeys, saveKeys } = useApiKeys()
   const { user, updateName, changePassword } = useAuth()
   const [name, setName] = useState(user?.name ?? '')
   const [currentPassword, setCurrentPassword] = useState('')
@@ -245,6 +245,10 @@ export function SettingsPanel() {
                 <Label htmlFor="gemini" className="text-white">Gemini Key</Label>
                 <Input id="gemini" value={geminiKey} onChange={e=>setKeys({geminiKey:e.target.value})} className="bg-white/5 border-white/10" />
               </div>
+              <Button onClick={saveKeys} className="bg-gradient-to-r from-[#00D4FF] to-[#00FF88] hover:from-[#00D4FF]/80 hover:to-[#00FF88]/80 text-black font-semibold ripple">
+                <Save className="h-4 w-4 mr-2" />
+                Save Keys
+              </Button>
             </CardContent>
           </Card>
         </TabsContent>

--- a/client/components/sidebar.tsx
+++ b/client/components/sidebar.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 import type React from "react"
 
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, FileText, Upload, Users, Settings, BarChart3, ChevronLeft, X } from "lucide-react"
+import { LayoutDashboard, FileText, Users, Settings, BarChart3, ChevronLeft, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useEffect, useState } from "react"
@@ -17,8 +17,6 @@ interface SidebarProps {
 
 const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
-  { name: "Quotations", href: "/quotations", icon: FileText },
-  { name: "Upload", href: "/upload", icon: Upload },
   { name: "Price Match", href: "/price-match", icon: FileText },
   { name: "Project Match", href: "/project-match", icon: FileText },
   { name: "Clients", href: "/clients", icon: Users },

--- a/client/contexts/api-keys-context.tsx
+++ b/client/contexts/api-keys-context.tsx
@@ -1,53 +1,62 @@
 "use client"
 
 import React, { createContext, useContext, useState, useEffect } from "react"
+import { useAuth } from "@/contexts/auth-context"
 
 interface ApiKeyContextType {
   openaiKey: string
   cohereKey: string
   geminiKey: string
   setKeys: (keys: Partial<{openaiKey:string;cohereKey:string;geminiKey:string}>) => void
+  saveKeys: () => void
 }
 
 const ApiKeyContext = createContext<ApiKeyContextType>({
   openaiKey: "",
   cohereKey: "",
   geminiKey: "",
-  setKeys: () => {}
+  setKeys: () => {},
+  saveKeys: () => {}
 })
 
 export function ApiKeyProvider({children}:{children:React.ReactNode}){
+  const { user } = useAuth()
+  const uid = user?.id ?? 'guest'
   const [openaiKey,setOpenai] = useState("")
   const [cohereKey,setCohere] = useState("")
   const [geminiKey,setGemini] = useState("")
 
   useEffect(() => {
-    const stored = localStorage.getItem("apiKeys")
+    const stored = localStorage.getItem(`apiKeys_${uid}`)
     if(stored){
       const k = JSON.parse(stored)
       setOpenai(k.openaiKey||"")
       setCohere(k.cohereKey||"")
       setGemini(k.geminiKey||"")
+    } else {
+      setOpenai("")
+      setCohere("")
+      setGemini("")
     }
-  },[])
+  },[uid])
 
   const setKeys = (keys: Partial<{openaiKey:string;cohereKey:string;geminiKey:string}>) => {
     if(keys.openaiKey!==undefined) setOpenai(keys.openaiKey)
     if(keys.cohereKey!==undefined) setCohere(keys.cohereKey)
     if(keys.geminiKey!==undefined) setGemini(keys.geminiKey)
-    const all = {
-      openaiKey: keys.openaiKey ?? openaiKey,
-      cohereKey: keys.cohereKey ?? cohereKey,
-      geminiKey: keys.geminiKey ?? geminiKey
-    }
-    localStorage.setItem("apiKeys", JSON.stringify(all))
+  }
+
+  const saveKeys = () => {
+    const all = { openaiKey, cohereKey, geminiKey }
+    localStorage.setItem(`apiKeys_${uid}`, JSON.stringify(all))
   }
 
   return (
-    <ApiKeyContext.Provider value={{openaiKey,cohereKey,geminiKey,setKeys}}>
+    <ApiKeyContext.Provider value={{openaiKey,cohereKey,geminiKey,setKeys,saveKeys}}>
       {children}
     </ApiKeyContext.Provider>
   )
 }
 
 export const useApiKeys = () => useContext(ApiKeyContext)
+

--- a/client/contexts/auth-context.tsx
+++ b/client/contexts/auth-context.tsx
@@ -6,13 +6,14 @@ import { loginUser, registerUser, updateProfile, changePassword } from "@/lib/ap
 interface User {
   id: string
   name: string
+  guests: number
 }
 
 interface AuthContextType {
   user: User | null
   token: string | null
   login: (email: string, password: string) => Promise<void>
-  register: (name: string, email: string, password: string) => Promise<void>
+  register: (name: string, email: string, password: string, guests: number) => Promise<void>
   updateName: (name: string) => Promise<void>
   changePassword: (current: string, password: string) => Promise<void>
   logout: () => void
@@ -48,8 +49,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem("auth", JSON.stringify(res))
   }
 
-  const register = async (name: string, email: string, password: string) => {
-    const res = await registerUser(name, email, password)
+  const register = async (name: string, email: string, password: string, guests: number) => {
+    const res = await registerUser(name, email, password, guests)
     setUser(res.user)
     setToken(res.token)
     localStorage.setItem("auth", JSON.stringify(res))

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -29,11 +29,11 @@ export async function loginUser(email: string, password: string) {
   return res.json()
 }
 
-export async function registerUser(name: string, email: string, password: string) {
+export async function registerUser(name: string, email: string, password: string, guests: number) {
   const res = await fetch(`${base}/api/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, email, password })
+    body: JSON.stringify({ name, email, password, guests })
   })
   if (!res.ok) {
     throw new Error('Registration failed')


### PR DESCRIPTION
## Summary
- remove quotations and upload links from navigation
- add home dashboard page
- require number of guests during registration
- store API keys per user and add save button
- support guests field in backend user model and auth routes

## Testing
- `npm test --prefix backend` *(fails: cannot find module 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_68482bcd590483259436c44f500d5276