### PR TITLE
Add editable price list page

### DIFF
--- a/client/app/price-list/page.tsx
+++ b/client/app/price-list/page.tsx
@@ -1,0 +1,18 @@
+import { DashboardLayout } from "@/components/dashboard-layout"
+import { PriceListModule } from "@/components/price-list-module"
+
+export default function PriceListPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-4xl font-bold bg-gradient-to-r from-[#00D4FF] to-[#00FF88] bg-clip-text text-transparent">
+            Price List
+          </h1>
+          <p className="text-muted-foreground mt-2">Manage and edit your master pricing</p>
+        </div>
+        <PriceListModule />
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/client/components/navigation/sidebar.tsx
+++ b/client/components/navigation/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, FileText, Upload, Users, Settings, BarChart3, ChevronLeft, X } from "lucide-react"
+import { LayoutDashboard, FileText, Upload, Users, Settings, BarChart3, CircleDollarSign, ChevronLeft, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useEffect, useCallback, memo } from "react"
@@ -15,6 +15,7 @@ import { useSwipeGesture } from "@/hooks/use-swipe-gesture"
 const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Quotations", href: "/quotations", icon: FileText },
+  { name: "Price List", href: "/price-list", icon: CircleDollarSign },
   { name: "Upload", href: "/upload", icon: Upload },
   { name: "Clients", href: "/clients", icon: Users },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },

--- a/client/components/price-list-module.tsx
+++ b/client/components/price-list-module.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { getPriceItems, searchPriceItems, updatePriceItem, PriceItem } from "@/lib/api"
+
+interface PriceItemExt extends PriceItem {
+  category?: string
+  subCategory?: string
+  keywords?: string[]
+  phrases?: string[]
+  ref?: string
+}
+
+export function PriceListModule() {
+  const [items, setItems] = useState<PriceItemExt[]>([])
+  const [search, setSearch] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [editing, setEditing] = useState<Record<string, Partial<PriceItemExt>>>({})
+
+  const load = async (term: string) => {
+    setLoading(true)
+    try {
+      const data = term ? await searchPriceItems(term) : await getPriceItems()
+      setItems(data as PriceItemExt[])
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load(search)
+  }, [search])
+
+  const handleChange = (id: string, field: keyof PriceItemExt, value: any) => {
+    setEditing(prev => ({
+      ...prev,
+      [id]: { ...prev[id], [field]: value },
+    }))
+  }
+
+  const handleSave = async (id: string) => {
+    const upd = editing[id]
+    if (!upd) return
+    const updates: any = { ...upd }
+    if (typeof updates.keywords === "string") {
+      updates.keywords = updates.keywords
+        .split(",")
+        .map((s: string) => s.trim())
+        .filter(Boolean)
+    }
+    if (typeof updates.phrases === "string") {
+      updates.phrases = updates.phrases
+        .split(",")
+        .map((s: string) => s.trim())
+        .filter(Boolean)
+    }
+    try {
+      const updated = await updatePriceItem(id, updates)
+      setItems(itms => itms.map(it => (it._id === id ? (updated as PriceItemExt) : it)))
+      setEditing(prev => {
+        const { [id]: _, ...rest } = prev
+        return rest
+      })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <Card className="glass-effect border-white/10">
+      <CardHeader>
+        <CardTitle className="text-white">Price List</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Input
+          placeholder="Search..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="max-w-sm bg-white/5 border-white/10 focus:border-[#00D4FF] focus:ring-[#00D4FF]/20"
+        />
+        {loading ? (
+          <p className="text-sm text-gray-400">Loading...</p>
+        ) : (
+          <div className="overflow-auto max-h-[70vh]">
+            <Table className="min-w-full text-xs">
+              <TableHeader>
+                <TableRow className="text-white">
+                  <TableHead>Description</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Sub Category</TableHead>
+                  <TableHead>Unit</TableHead>
+                  <TableHead>Rate</TableHead>
+                  <TableHead>Keywords</TableHead>
+                  <TableHead>Phrases</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map(item => {
+                  const values = editing[item._id ?? ""] || {}
+                  return (
+                    <TableRow key={item._id} className="border-b border-white/10">
+                      <TableCell>
+                        <Input
+                          className="bg-white/5 border-white/10"
+                          value={values.description ?? item.description}
+                          onChange={e => handleChange(item._id!, "description", e.target.value)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="bg-white/5 border-white/10"
+                          value={values.category ?? item.category ?? ""}
+                          onChange={e => handleChange(item._id!, "category", e.target.value)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="bg-white/5 border-white/10"
+                          value={values.subCategory ?? item.subCategory ?? ""}
+                          onChange={e => handleChange(item._id!, "subCategory", e.target.value)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="bg-white/5 border-white/10"
+                          value={values.unit ?? item.unit ?? ""}
+                          onChange={e => handleChange(item._id!, "unit", e.target.value)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          type="number"
+                          className="bg-white/5 border-white/10"
+                          value={values.rate ?? item.rate ?? ""}
+                          onChange={e => handleChange(item._id!, "rate", parseFloat(e.target.value))}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="bg-white/5 border-white/10"
+                          value={values.keywords ?? (item.keywords || []).join(", ")}
+                          onChange={e => handleChange(item._id!, "keywords", e.target.value)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="bg-white/5 border-white/10"
+                          value={values.phrases ?? (item.phrases || []).join(", ")}
+                          onChange={e => handleChange(item._id!, "phrases", e.target.value)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Button size="sm" onClick={() => handleSave(item._id!)} className="bg-[#00D4FF]/20 hover:bg-[#00D4FF]/30 text-[#00D4FF] border-[#00D4FF]/30 ripple">
+                          Save
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/client/components/sidebar.tsx
+++ b/client/components/sidebar.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 import type React from "react"
 
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, FileText, Users, Settings, BarChart3, ChevronLeft, X } from "lucide-react"
+import { LayoutDashboard, FileText, Users, Settings, BarChart3, CircleDollarSign, ChevronLeft, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useEffect, useState } from "react"
@@ -19,6 +19,7 @@ const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Price Match", href: "/price-match", icon: FileText },
   { name: "Project Match", href: "/project-match", icon: FileText },
+  { name: "Price List", href: "/price-list", icon: CircleDollarSign },
   { name: "Clients", href: "/clients", icon: Users },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Settings", href: "/settings", icon: Settings },

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -83,14 +83,35 @@ export async function changePassword(currentPassword: string, newPassword: strin
 export interface PriceItem {
   _id?: string
   code?: string
+  ref?: string
   description: string
+  category?: string
+  subCategory?: string
   unit?: string
   rate?: number
+  keywords?: string[]
+  phrases?: string[]
 }
 
 export async function searchPriceItems(query: string): Promise<PriceItem[]> {
   const url = `${base}/api/prices/search?q=${encodeURIComponent(query)}`
   const res = await fetch(url)
   if (!res.ok) throw new Error('Search failed')
+  return res.json()
+}
+
+export async function getPriceItems(): Promise<PriceItem[]> {
+  const res = await fetch(`${base}/api/prices`)
+  if (!res.ok) throw new Error('Failed to fetch prices')
+  return res.json()
+}
+
+export async function updatePriceItem(id: string, updates: Partial<PriceItem>): Promise<PriceItem> {
+  const res = await fetch(`${base}/api/prices/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  })
+  if (!res.ok) throw new Error('Update failed')
   return res.json()
 }


### PR DESCRIPTION
## Summary
- add API helpers for listing and updating price items
- implement `PriceListModule` with editing UI
- create `/price-list` page using the module
- link new page from both sidebars

## Testing
- `npm test --prefix backend` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_b_684839423f908325960e2acb9cb98e7c