### PR TITLE
Restore quotations tab to dashboard

### DIFF
--- a/client/components/bottom-nav.tsx
+++ b/client/components/bottom-nav.tsx
@@ -2,12 +2,13 @@
 
 import { usePathname } from "next/navigation"
 import Link from "next/link"
-import { LayoutDashboard, Users, Settings } from "lucide-react"
+import { LayoutDashboard, FileText, Users, Settings } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useMobileOptimization } from "@/components/mobile-optimization-provider"
 
 const navItems = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Quotations", href: "/quotations", icon: FileText },
   { name: "Clients", href: "/clients", icon: Users },
   { name: "Settings", href: "/settings", icon: Settings },
 ]

--- a/client/components/sidebar.tsx
+++ b/client/components/sidebar.tsx
@@ -17,6 +17,7 @@ interface SidebarProps {
 
 const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Quotations", href: "/quotations", icon: FileText },
   { name: "Price Match", href: "/price-match", icon: FileText },
   { name: "Project Match", href: "/project-match", icon: FileText },
   { name: "Price List", href: "/price-list", icon: CircleDollarSign },


### PR DESCRIPTION
## Summary
- add Quotations link back to the sidebar nav
- show Quotations in mobile bottom navigation

## Testing
- `npm test --prefix backend` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_68484330c6f4832584f005dffa38e052