### PR TITLE
Enforce authentication across app

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -11,6 +11,7 @@ import projectRoutes from './routes/project.routes.js';
 import boqRoutes from './routes/boq.routes.js';
 import matchRoutes from './routes/match.routes.js';
 import priceRoutes from './routes/price.routes.js';
+import auth from './middlewares/auth.js';
 
 const app = express();
 
@@ -21,9 +22,9 @@ app.use(express.json({ limit: '10mb', strict: false })); // important for Lambda
 
 // ✅ Routes
 app.use('/api/auth', authRoutes);
-app.use('/api/projects', projectRoutes);
-app.use('/api/boq', boqRoutes);
-app.use('/api/match', matchRoutes);
-app.use('/api/prices', priceRoutes);
+app.use('/api/projects', auth, projectRoutes);
+app.use('/api/boq', auth, boqRoutes);
+app.use('/api/match', auth, matchRoutes);
+app.use('/api/prices', auth, priceRoutes);
 
 export default app;

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { MobileOptimizationProvider } from "@/components/mobile-optimization-provider"
 import { AuthProvider } from "@/contexts/auth-context"
+import RequireAuth from "@/components/require-auth"
 import { ApiKeyProvider } from "@/contexts/api-keys-context"
 
 const inter = Inter({
@@ -55,7 +56,9 @@ export default function RootLayout({
           <MobileOptimizationProvider>
             <AuthProvider>
               <ApiKeyProvider>
-                {children}
+                <RequireAuth>
+                  {children}
+                </RequireAuth>
                 <Toaster />
               </ApiKeyProvider>
             </AuthProvider>

--- a/client/components/project-match-module.tsx
+++ b/client/components/project-match-module.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, TableFooter } from "@/components/ui/table"
 import { Progress } from "@/components/ui/progress"
 import { useApiKeys } from "@/contexts/api-keys-context"
+import { useAuth } from "@/contexts/auth-context"
 import * as XLSX from "xlsx"
 
 interface MatchRow {
@@ -27,6 +28,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || ''
 
 export default function ProjectMatchModule(){
   const { openaiKey, cohereKey, geminiKey } = useApiKeys()
+  const { token } = useAuth()
   const [rows,setRows] = useState<MatchRow[]>([])
   const [loading,setLoading] = useState(false)
   const [progress,setProgress] = useState(0)
@@ -52,7 +54,12 @@ export default function ProjectMatchModule(){
     setProgress(0)
     timerRef.current = setInterval(()=>setProgress(p=>p<90?p+5:90),500)
     try{
-      const res = await fetch(`${API_URL}/api/match`,{method:'POST',body:form})
+      if(!token) throw new Error('No auth')
+      const res = await fetch(`${API_URL}/api/match`,{
+        method:'POST',
+        headers:{ Authorization: `Bearer ${token}` },
+        body:form
+      })
       if(!res.ok) throw new Error('Match failed')
       const data = await res.json()
       const formatted:MatchRow[] = data.map((r:any)=>{

--- a/client/components/require-auth.tsx
+++ b/client/components/require-auth.tsx
@@ -1,0 +1,22 @@
+"use client"
+import { useAuth } from "@/contexts/auth-context"
+import { useRouter, usePathname } from "next/navigation"
+import { useEffect } from "react"
+
+export default function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (!user && pathname !== "/login" && pathname !== "/register") {
+      router.replace("/login")
+    }
+  }, [user, pathname, router])
+
+  if (!user && pathname !== "/login" && pathname !== "/register") {
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -9,8 +9,10 @@ export interface Project {
 
 const base = process.env.NEXT_PUBLIC_API_URL ?? ''
 
-export async function getProjects(): Promise<Project[]> {
-  const res = await fetch(`${base}/api/projects`)
+export async function getProjects(token: string): Promise<Project[]> {
+  const res = await fetch(`${base}/api/projects`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
   if (!res.ok) {
     throw new Error(`Failed to fetch projects: ${res.status}`)
   }
@@ -41,13 +43,17 @@ export async function registerUser(name: string, email: string, password: string
   return res.json()
 }
 
-export async function priceMatch(file: File, keys: {openaiKey?:string; cohereKey?:string; geminiKey?:string}) {
+export async function priceMatch(file: File, keys: {openaiKey?:string; cohereKey?:string; geminiKey?:string}, token: string) {
   const form = new FormData()
   form.append('file', file)
   if (keys.openaiKey) form.append('openaiKey', keys.openaiKey)
   if (keys.cohereKey) form.append('cohereKey', keys.cohereKey)
   if (keys.geminiKey) form.append('geminiKey', keys.geminiKey)
-  const res = await fetch(`${base}/api/match`, { method: 'POST', body: form })
+  const res = await fetch(`${base}/api/match`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+  })
   if (!res.ok) {
     throw new Error('Price match failed')
   }
@@ -93,23 +99,23 @@ export interface PriceItem {
   phrases?: string[]
 }
 
-export async function searchPriceItems(query: string): Promise<PriceItem[]> {
+export async function searchPriceItems(query: string, token: string): Promise<PriceItem[]> {
   const url = `${base}/api/prices/search?q=${encodeURIComponent(query)}`
-  const res = await fetch(url)
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } })
   if (!res.ok) throw new Error('Search failed')
   return res.json()
 }
 
-export async function getPriceItems(): Promise<PriceItem[]> {
-  const res = await fetch(`${base}/api/prices`)
+export async function getPriceItems(token: string): Promise<PriceItem[]> {
+  const res = await fetch(`${base}/api/prices`, { headers: { Authorization: `Bearer ${token}` } })
   if (!res.ok) throw new Error('Failed to fetch prices')
   return res.json()
 }
 
-export async function updatePriceItem(id: string, updates: Partial<PriceItem>): Promise<PriceItem> {
+export async function updatePriceItem(id: string, updates: Partial<PriceItem>, token: string): Promise<PriceItem> {
   const res = await fetch(`${base}/api/prices/${id}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(updates),
   })
   if (!res.ok) throw new Error('Update failed')


### PR DESCRIPTION
## Summary
- require auth middleware for project, BoQ, match and price APIs
- add RequireAuth component for the frontend
- wrap all pages with RequireAuth
- pass JWT when calling protected API routes

## Testing
- `npm test --prefix backend` *(fails: ERR_ASSERTION and ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_b_6848441ff14083258adf7f23af276139