### PR TITLE
Remove dashboard tabs and add sign out

### DIFF
--- a/client/app/login/page.tsx
+++ b/client/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
+import Link from "next/link"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
@@ -44,6 +45,12 @@ export default function LoginPage() {
             {error && <p className="text-red-500 text-sm">{error}</p>}
             <Button type="submit" className="w-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] text-black font-semibold">Login</Button>
           </form>
+          <p className="text-sm text-center text-gray-400 mt-4">
+            Don't have an account?{' '}
+            <Link href="/register" className="text-[#00D4FF] hover:underline">
+              Sign Up
+            </Link>
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/client/components/bottom-nav.tsx
+++ b/client/components/bottom-nav.tsx
@@ -2,12 +2,11 @@
 
 import { usePathname } from "next/navigation"
 import Link from "next/link"
-import { LayoutDashboard, FileText, Users, Settings } from "lucide-react"
+import { FileText, Users, Settings } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useMobileOptimization } from "@/components/mobile-optimization-provider"
 
 const navItems = [
-  { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Quotations", href: "/quotations", icon: FileText },
   { name: "Clients", href: "/clients", icon: Users },
   { name: "Settings", href: "/settings", icon: Settings },

--- a/client/components/navigation/bottom-nav.tsx
+++ b/client/components/navigation/bottom-nav.tsx
@@ -4,13 +4,12 @@ import type React from "react"
 
 import { usePathname } from "next/navigation"
 import Link from "next/link"
-import { LayoutDashboard, FileText, Upload, Users, Settings } from "lucide-react"
+import { FileText, Upload, Users, Settings } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useMobileOptimization } from "@/hooks/use-mobile-optimization"
 import { memo } from "react"
 
 const navItems = [
-  { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Quotations", href: "/quotations", icon: FileText },
   { name: "Upload", href: "/upload", icon: Upload },
   { name: "Clients", href: "/clients", icon: Users },

--- a/client/components/navigation/sidebar.tsx
+++ b/client/components/navigation/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, FileText, Upload, Users, Settings, BarChart3, CircleDollarSign, ChevronLeft, X } from "lucide-react"
+import { FileText, Upload, Users, Settings, BarChart3, CircleDollarSign, ChevronLeft, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useEffect, useCallback, memo } from "react"
@@ -13,7 +13,6 @@ import { UserProfile } from "@/components/user/user-profile"
 import { useSwipeGesture } from "@/hooks/use-swipe-gesture"
 
 const navigation = [
-  { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Quotations", href: "/quotations", icon: FileText },
   { name: "Price List", href: "/price-list", icon: CircleDollarSign },
   { name: "Upload", href: "/upload", icon: Upload },

--- a/client/components/sidebar.tsx
+++ b/client/components/sidebar.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 import type React from "react"
 
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, FileText, Users, Settings, BarChart3, CircleDollarSign, ChevronLeft, X } from "lucide-react"
+import { FileText, Users, Settings, BarChart3, CircleDollarSign, ChevronLeft, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useEffect, useState } from "react"
@@ -16,10 +16,8 @@ interface SidebarProps {
 }
 
 const navigation = [
-  { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Quotations", href: "/quotations", icon: FileText },
   { name: "Price Match", href: "/price-match", icon: FileText },
-  { name: "Project Match", href: "/project-match", icon: FileText },
   { name: "Price List", href: "/price-list", icon: CircleDollarSign },
   { name: "Clients", href: "/clients", icon: Users },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },

--- a/client/components/user/user-profile.tsx
+++ b/client/components/user/user-profile.tsx
@@ -1,5 +1,7 @@
 import { memo } from "react"
+import { useRouter } from "next/navigation"
 import { useAuth } from "@/contexts/auth-context"
+import { Button } from "@/components/ui/button"
 
 interface UserProfileProps {
   collapsed: boolean
@@ -10,14 +12,25 @@ export const UserProfile = memo(function UserProfile({ collapsed }: UserProfileP
     return null
   }
 
-  const { user } = useAuth()
+  const router = useRouter()
+  const { user, logout } = useAuth()
+
+  const handleLogout = () => {
+    logout()
+    router.push('/login')
+  }
 
   return (
-    <div className="flex items-center space-x-3">
-      <div className="h-8 w-8 rounded-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] flex-shrink-0" />
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-white truncate">{user?.name ?? 'Guest'}</p>
+    <div className="flex items-center justify-between space-x-3">
+      <div className="flex items-center space-x-3">
+        <div className="h-8 w-8 rounded-full bg-gradient-to-r from-[#00D4FF] to-[#00FF88] flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-white truncate">{user?.name ?? 'Guest'}</p>
+        </div>
       </div>
+      <Button size="sm" variant="ghost" onClick={handleLogout} className="text-red-500 hover:bg-white/10">
+        Sign Out
+      </Button>
     </div>
   )
 })


### PR DESCRIPTION
## Summary
- remove Dashboard and Project Match navigation entries
- add a Sign Out button in the user profile
- link to a Register page from the login page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68485bd2a40083258a314b670a650789