### PR TITLE
Improve Price Match usability

### DIFF
--- a/client/components/navigation/sidebar.tsx
+++ b/client/components/navigation/sidebar.tsx
@@ -162,7 +162,13 @@ const NavItems = memo(function NavItems({
             )}
             aria-current={isActive ? "page" : undefined}
           >
-            <item.icon className={cn("h-5 w-5 flex-shrink-0", isActive && "neon-blue")} />
+            <item.icon
+              className={cn(
+                collapsed ? "h-6 w-6" : "h-5 w-5",
+                "flex-shrink-0",
+                isActive && "neon-blue"
+              )}
+            />
             {!collapsed && <span>{item.name}</span>}
           </Link>
         )


### PR DESCRIPTION
## Summary
- show live backend logs via SSE during price matching
- style price match file input with gray background
- enlarge sidebar icons when collapsed
- fix search in price match by sending auth token

## Testing
- `npm test` *(fails: cannot find package 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_684863acdcb08325a6bf41e09d717da1