### PR TITLE
Fix Amplify build without lock file

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ frontend:
     preBuild:
       commands:
         - cd client
-        - npm ci
+        - npm install
     build:
       commands:
         - npm run build # NO cd here!


### PR DESCRIPTION
## Summary
- fix Amplify build step so it installs without a lock file

## Testing
- `npm test --prefix backend` *(fails: ERR_ASSERTION / ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_b_684874205788832591522c1a19d7c11b