### PR TITLE
Fix date library issues and adjust Amplify build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,7 +9,7 @@ frontend:
       commands:
         - npm run build # NO cd here!
   artifacts:
-    baseDirectory: client/dist # or client/build, depending on your config
+    baseDirectory: client/.next
     files:
       - "**/*"
   cache:

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import dayjs from "dayjs"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -35,11 +36,7 @@ export function formatCurrency(value: number, currency = "USD") {
 
 // Format date
 export function formatDate(date: string | Date) {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  }).format(new Date(date))
+  return dayjs(date).format("MMM D, YYYY")
 }
 
 // Throttle function

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
-    "date-fns": "4.1.0",
+    "dayjs": "^1.11.10",
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",


### PR DESCRIPTION
## Summary
- remove `date-fns` and use `dayjs` instead
- update date formatting utility to rely on `dayjs`
- adjust Amplify config for Next.js output

## Testing
- `npm test --prefix backend` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_b_6848759f909c8325b1a73ac0881d9692