### PR TITLE
Update analytics and price match workflow

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -49,11 +49,13 @@ router.post('/', upload.single('file'), async (req, res) => {
   try {
     let results;
     if (openaiKey && cohereKey) {
+      console.log('Calling OpenAI matcher');
       const openaiResults = await openAiMatchFromFiles(
         PRICE_FILE,
         req.file.buffer,
         openaiKey
       );
+      console.log('Calling Cohere matcher');
       const cohereResults = await cohereMatchFromFiles(
         PRICE_FILE,
         req.file.buffer,
@@ -70,8 +72,10 @@ router.post('/', upload.single('file'), async (req, res) => {
         };
       });
     } else if (openaiKey) {
+      console.log('Calling OpenAI matcher');
       results = await openAiMatchFromFiles(PRICE_FILE, req.file.buffer, openaiKey);
     } else if (cohereKey) {
+      console.log('Calling Cohere matcher');
       results = await cohereMatchFromFiles(
         PRICE_FILE,
         req.file.buffer,

--- a/client/components/clients-grid.tsx
+++ b/client/components/clients-grid.tsx
@@ -1,66 +1,53 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Building, Mail, Phone, MapPin, Eye } from "lucide-react"
+import { loadQuotations } from "@/lib/quotation-store"
+import { formatCurrency } from "@/lib/utils"
 
-const clients = [
-  {
-    id: 1,
-    name: "Metro Construction Ltd.",
-    type: "Construction Company",
-    email: "contact@metroconstruction.com",
-    phone: "+1 (555) 123-4567",
-    address: "123 Business District, Metro City",
-    projects: 12,
-    totalValue: "$4.2M",
-    status: "Premium",
-  },
-  {
-    id: 2,
-    name: "Urban Developers Inc.",
-    type: "Real Estate Developer",
-    email: "info@urbandevelopers.com",
-    phone: "+1 (555) 234-5678",
-    address: "456 Development Ave, Urban City",
-    projects: 8,
-    totalValue: "$2.8M",
-    status: "Active",
-  },
-  {
-    id: 3,
-    name: "City Infrastructure",
-    type: "Government Agency",
-    email: "projects@cityinfra.gov",
-    phone: "+1 (555) 345-6789",
-    address: "789 Government Plaza, City Hall",
-    projects: 15,
-    totalValue: "$8.1M",
-    status: "Premium",
-  },
-  {
-    id: 4,
-    name: "Green Building Corp.",
-    type: "Sustainable Construction",
-    email: "hello@greenbuilding.com",
-    phone: "+1 (555) 456-7890",
-    address: "321 Eco Street, Green Valley",
-    projects: 6,
-    totalValue: "$1.9M",
-    status: "Active",
-  },
-]
+
+interface ClientInfo {
+  id: number
+  name: string
+  projects: number
+  totalValue: string
+  status: string
+  type?: string
+  email?: string
+  phone?: string
+  address?: string
+}
 
 export function ClientsGrid() {
   const [searchTerm, setSearchTerm] = useState("")
+  const [clients, setClients] = useState<ClientInfo[]>([])
+
+  useEffect(() => {
+    loadQuotations().then(qs => {
+      const map = new Map<string, { projects: number; total: number }>()
+      qs.forEach(q => {
+        const info = map.get(q.client) || { projects: 0, total: 0 }
+        info.projects += 1
+        info.total += q.value
+        map.set(q.client, info)
+      })
+      const arr: ClientInfo[] = Array.from(map.entries()).map(([name, info], idx) => ({
+        id: idx + 1,
+        name,
+        projects: info.projects,
+        totalValue: formatCurrency(info.total),
+        status: "Active"
+      }))
+      setClients(arr)
+    })
+  }, [])
 
   const filteredClients = clients.filter(
-    (client) =>
-      client.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      client.type.toLowerCase().includes(searchTerm.toLowerCase()),
+    client => client.name.toLowerCase().includes(searchTerm.toLowerCase())
   )
 
   return (

--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -42,6 +42,7 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
   const [discountInput, setDiscountInput] = useState(0)
   const [discount, setDiscount] = useState(0)
   const [projectName, setProjectName] = useState("")
+  const [clientName, setClientName] = useState("")
   const [page, setPage] = useState(0)
   const pageSize = 100
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -203,8 +204,8 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
 
   const handleSave = () => {
     if (!results) return
-    if (!projectName.trim()) {
-      alert('Project name is required')
+    if (!projectName.trim() || !clientName.trim()) {
+      alert('Project and client name are required')
       return
     }
     const items = results.map((r, idx) => {
@@ -222,7 +223,7 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
     const value = items.reduce((s, i) => s + i.total, 0)
     const quotation = {
       id: `QT-${Date.now()}`,
-      client: 'Unknown Client',
+      client: clientName,
       project: projectName,
       value,
       status: 'pending',
@@ -251,6 +252,12 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
           placeholder="Project Name"
           value={projectName}
           onChange={e => setProjectName(e.target.value)}
+          className="bg-gray-800/20 border-white/10"
+        />
+        <Input
+          placeholder="Client Name"
+          value={clientName}
+          onChange={e => setClientName(e.target.value)}
           className="bg-gray-800/20 border-white/10"
         />
         <Input


### PR DESCRIPTION
## Summary
- compute analytics from existing quotations
- derive clients list from stored quotations
- require client name when saving matches
- show logs for external price match engines

## Testing
- `npm test --prefix backend` *(fails: Cannot find package 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_684956c027748325b83845fefa5b2bae