### PR TITLE
Use DB for OpenAI/Cohere price matchers

### DIFF
--- a/backend/src/services/matchService.js
+++ b/backend/src/services/matchService.js
@@ -48,7 +48,7 @@ function removeStopWords(text) {
     .join(' ');
 }
 
-function preprocess(text) {
+export function preprocess(text) {
   const cleaned = String(text || '')
     .toLowerCase()
     .replace(/[^a-z0-9\s]/g, ' ')


### PR DESCRIPTION
## Summary
- expose `preprocess` for reuse
- add DB powered versions of OpenAI and Cohere matchers
- select DB or file based matcher in API based on `CONNECTION_STRING`

## Testing
- `npm test --prefix backend` *(fails: cannot find module 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_68497d2a14f48325ba4f1404175f5112