### PR TITLE
Fix await usage in price-match page

### DIFF
--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -202,7 +202,7 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
     )
   })
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!results) return
     if (!projectName.trim() || !clientName.trim()) {
       alert('Project and client name are required')


### PR DESCRIPTION
## Summary
- make `handleSave` asynchronous in `price-match-module`

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849895630488325851e20de38ea0af3