### PR TITLE
Implement price list pagination

### DIFF
--- a/client/app/price-list/page.tsx
+++ b/client/app/price-list/page.tsx
@@ -4,15 +4,7 @@ import { PriceListModule } from "@/components/price-list-module"
 export default function PriceListPage() {
   return (
     <DashboardLayout>
-      <div className="space-y-8">
-        <div>
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-[#00D4FF] to-[#00FF88] bg-clip-text text-transparent">
-            Price List
-          </h1>
-          <p className="text-muted-foreground mt-2">Manage and edit your master pricing</p>
-        </div>
-        <PriceListModule />
-      </div>
+      <PriceListModule />
     </DashboardLayout>
   )
 }

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -111,8 +111,23 @@ export async function searchPriceItems(query: string, token: string): Promise<Pr
   return res.json()
 }
 
-export async function getPriceItems(token: string): Promise<PriceItem[]> {
-  const res = await fetch(`${base}/api/prices`, { headers: { Authorization: `Bearer ${token}` } })
+export interface PaginatedResult<T> {
+  items: T[]
+  total: number
+}
+
+export async function getPriceItems(
+  token: string,
+  opts: { page?: number; limit?: number; sort?: string; q?: string } = {}
+): Promise<PaginatedResult<PriceItem>> {
+  const params = new URLSearchParams()
+  if (opts.page) params.append('page', String(opts.page))
+  if (opts.limit) params.append('limit', String(opts.limit))
+  if (opts.sort) params.append('sort', opts.sort)
+  if (opts.q) params.append('q', opts.q)
+  const res = await fetch(`${base}/api/prices?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
   if (!res.ok) throw new Error('Failed to fetch prices')
   return res.json()
 }


### PR DESCRIPTION
## Summary
- add pagination, sorting and filtering on backend price routes
- expose paginated price fetch on frontend API
- integrate pagination controls and sorting in price list module
- remove page header from price list page

## Testing
- `npm test --prefix backend` *(fails: ERR_ASSERTION)*
- `npm run lint --prefix client` *(fails: next: not found)*
- `npm run build --prefix client` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498c1e06c0832588cd8cf62a68589b