### PR TITLE
Add asynchronous price matching support

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -1,28 +1,35 @@
-import { Router } from 'express';
-import multer from 'multer';
-import path from 'path';
-import { EventEmitter } from 'events';
-import { openAiMatchFromFiles, openAiMatchFromDb } from '../services/openAiService.js';
-import { cohereMatchFromFiles, cohereMatchFromDb } from '../services/cohereService.js';
-import { matchFromFiles } from '../services/matchService.js';
-import { fileURLToPath } from 'url';
-
+import { Router } from "express";
+import multer from "multer";
+import path from "path";
+import { EventEmitter } from "events";
+import { nanoid } from "nanoid";
+import {
+  openAiMatchFromFiles,
+  openAiMatchFromDb,
+} from "../services/openAiService.js";
+import {
+  cohereMatchFromFiles,
+  cohereMatchFromDb,
+} from "../services/cohereService.js";
+import { matchFromFiles } from "../services/matchService.js";
+import { fileURLToPath } from "url";
 
 const upload = multer({ storage: multer.memoryStorage() });
 const router = Router();
 export const matchEmitter = new EventEmitter();
+const jobMap = new Map();
 
-router.get('/logs', (req, res) => {
+router.get("/logs", (req, res) => {
   res.set({
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    Connection: 'keep-alive'
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
   });
   res.flushHeaders();
   const send = (msg) => res.write(`data: ${msg}\n\n`);
-  matchEmitter.on('log', send);
-  req.on('close', () => {
-    matchEmitter.off('log', send);
+  matchEmitter.on("log", send);
+  req.on("close", () => {
+    matchEmitter.off("log", send);
   });
 });
 
@@ -30,31 +37,50 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // Resolve to the repo root's frontend price list file
 // Current file is located at backend/src/routes, so go up three levels
 // to reach the repo root before appending the frontend path
-const PRICE_FILE = path.resolve(__dirname, '../../MJD-PRICELIST.xlsx');
+const PRICE_FILE = path.resolve(__dirname, "../../MJD-PRICELIST.xlsx");
 
-router.post('/', upload.single('file'), async (req, res) => {
-  if (!req.file) return res.status(400).json({ message: 'No file uploaded' });
+function scheduleCleanup(id) {
+  setTimeout(() => jobMap.delete(id), 60 * 60 * 1000);
+}
+
+router.get("/:jobId", (req, res) => {
+  const job = jobMap.get(req.params.jobId);
+  if (!job) return res.status(404).json({ message: "Job not found" });
+  if (job.error) {
+    const { message } = job.error;
+    jobMap.delete(req.params.jobId);
+    return res.status(400).json({ status: "error", message });
+  }
+  if (!job.done) return res.json({ status: "running" });
+  const result = job.result;
+  jobMap.delete(req.params.jobId);
+  res.json({ status: "done", result });
+});
+
+router.post("/", upload.single("file"), async (req, res) => {
+  if (!req.file) return res.status(400).json({ message: "No file uploaded" });
   const origLog = console.log;
   console.log = (...args) => {
     origLog(...args);
-    matchEmitter.emit('log', args.join(' '));
+    matchEmitter.emit("log", args.join(" "));
   };
-  console.log('Price match upload:', {
+  console.log("Price match upload:", {
     name: req.file.originalname,
-    size: req.file.size
+    size: req.file.size,
   });
   const { openaiKey, cohereKey } = req.body;
-  console.log('OpenAI key provided:', !!openaiKey);
-  console.log('Cohere key provided:', !!cohereKey);
-  try {
+  console.log("OpenAI key provided:", !!openaiKey);
+  console.log("Cohere key provided:", !!cohereKey);
+
+  const run = async () => {
     let results;
     const useDb = !!process.env.CONNECTION_STRING;
     if (openaiKey && cohereKey) {
-      console.log('Calling OpenAI matcher');
+      console.log("Calling OpenAI matcher");
       const openaiResults = await (useDb
         ? openAiMatchFromDb(req.file.buffer, openaiKey)
         : openAiMatchFromFiles(PRICE_FILE, req.file.buffer, openaiKey));
-      console.log('Calling Cohere matcher');
+      console.log("Calling Cohere matcher");
       const cohereResults = await (useDb
         ? cohereMatchFromDb(req.file.buffer, cohereKey)
         : cohereMatchFromFiles(PRICE_FILE, req.file.buffer, cohereKey));
@@ -65,16 +91,16 @@ router.post('/', upload.single('file'), async (req, res) => {
         return {
           inputDescription: o.inputDescription,
           quantity: o.quantity,
-          matches: [openaiBest, cohereBest].filter(Boolean)
+          matches: [openaiBest, cohereBest].filter(Boolean),
         };
       });
     } else if (openaiKey) {
-      console.log('Calling OpenAI matcher');
+      console.log("Calling OpenAI matcher");
       results = await (useDb
         ? openAiMatchFromDb(req.file.buffer, openaiKey)
         : openAiMatchFromFiles(PRICE_FILE, req.file.buffer, openaiKey));
     } else if (cohereKey) {
-      console.log('Calling Cohere matcher');
+      console.log("Calling Cohere matcher");
       results = await (useDb
         ? cohereMatchFromDb(req.file.buffer, cohereKey)
         : cohereMatchFromFiles(PRICE_FILE, req.file.buffer, cohereKey));
@@ -82,14 +108,38 @@ router.post('/', upload.single('file'), async (req, res) => {
       // Fallback to built-in matcher when no external API key is provided
       results = matchFromFiles(PRICE_FILE, req.file.buffer);
     }
-    console.log('Price match results:', results.length);
-    matchEmitter.emit('log', 'DONE');
+    console.log("Price match results:", results.length);
+    matchEmitter.emit("log", "DONE");
+    return results;
+  };
+
+  const asyncMode = String(req.query.async) === "1";
+  try {
+    if (asyncMode) {
+      const jobId = nanoid();
+      jobMap.set(jobId, { done: false });
+      run()
+        .then((result) => {
+          jobMap.set(jobId, { done: true, result });
+          scheduleCleanup(jobId);
+        })
+        .catch((err) => {
+          jobMap.set(jobId, { done: true, error: err });
+          scheduleCleanup(jobId);
+        })
+        .finally(() => {
+          console.log = origLog;
+        });
+      return res.json({ jobId });
+    }
+
+    const results = await run();
     res.json(results);
   } catch (err) {
-    console.error('Price match error:', err);
+    console.error("Price match error:", err);
     res.status(400).json({ message: err.message });
   } finally {
-    console.log = origLog;
+    if (!asyncMode) console.log = origLog;
   }
 });
 

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,161 +1,205 @@
 export interface Project {
-  id: string
-  client: string
-  type: string
-  due: string
-  status: string
-  value?: number
+  id: string;
+  client: string;
+  type: string;
+  due: string;
+  status: string;
+  value?: number;
 }
 
-const base = process.env.NEXT_PUBLIC_API_URL ?? ''
+const base = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export async function getProjects(token: string): Promise<Project[]> {
   const res = await fetch(`${base}/api/projects`, {
     headers: { Authorization: `Bearer ${token}` },
-  })
+  });
   if (!res.ok) {
-    throw new Error(`Failed to fetch projects: ${res.status}`)
+    throw new Error(`Failed to fetch projects: ${res.status}`);
   }
-  return res.json()
+  return res.json();
 }
 
 export async function loginUser(email: string, password: string) {
   const res = await fetch(`${base}/api/auth/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password })
-  })
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
   if (!res.ok) {
-    throw new Error('Login failed')
+    throw new Error("Login failed");
   }
-  return res.json()
+  return res.json();
 }
 
-export async function registerUser(name: string, email: string, password: string, guests: number) {
+export async function registerUser(
+  name: string,
+  email: string,
+  password: string,
+  guests: number,
+) {
   const res = await fetch(`${base}/api/auth/register`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, email, password, guests })
-  })
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, email, password, guests }),
+  });
   if (!res.ok) {
-    throw new Error('Registration failed')
+    throw new Error("Registration failed");
   }
-  return res.json()
+  return res.json();
 }
 
-export async function priceMatch(file: File, keys: {openaiKey?:string; cohereKey?:string; geminiKey?:string}, token: string) {
-  const form = new FormData()
-  form.append('file', file)
-  if (keys.openaiKey) form.append('openaiKey', keys.openaiKey)
-  if (keys.cohereKey) form.append('cohereKey', keys.cohereKey)
-  if (keys.geminiKey) form.append('geminiKey', keys.geminiKey)
-  const res = await fetch(`${base}/api/match`, {
-    method: 'POST',
+export async function priceMatch(
+  file: File,
+  keys: { openaiKey?: string; cohereKey?: string; geminiKey?: string },
+  token: string,
+  asyncMode = false,
+) {
+  const form = new FormData();
+  form.append("file", file);
+  if (keys.openaiKey) form.append("openaiKey", keys.openaiKey);
+  if (keys.cohereKey) form.append("cohereKey", keys.cohereKey);
+  if (keys.geminiKey) form.append("geminiKey", keys.geminiKey);
+  const url = asyncMode ? `${base}/api/match?async=1` : `${base}/api/match`;
+  const res = await fetch(url, {
+    method: "POST",
     headers: { Authorization: `Bearer ${token}` },
     body: form,
-  })
+  });
   if (!res.ok) {
-    let message = 'Price match failed'
+    let message = "Price match failed";
     try {
-      const data = await res.json()
-      if (data && data.message) message = data.message
+      const data = await res.json();
+      if (data && data.message) message = data.message;
     } catch {}
-    throw new Error(message)
+    throw new Error(message);
   }
-  return res.json()
+  return res.json();
+}
+
+export async function pollMatch(jobId: string, token: string) {
+  const res = await fetch(`${base}/api/match/${jobId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error("Polling failed");
+  return res.json();
 }
 
 export async function updateProfile(name: string, token: string) {
   const res = await fetch(`${base}/api/auth/profile`, {
-    method: 'PATCH',
+    method: "PATCH",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ name }),
-  })
-  if (!res.ok) throw new Error('Update failed')
-  return res.json()
+  });
+  if (!res.ok) throw new Error("Update failed");
+  return res.json();
 }
 
-export async function changePassword(currentPassword: string, newPassword: string, token: string) {
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string,
+  token: string,
+) {
   const res = await fetch(`${base}/api/auth/password`, {
-    method: 'PATCH',
+    method: "PATCH",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ currentPassword, newPassword }),
-  })
-  if (!res.ok) throw new Error('Password update failed')
-  return res.json()
+  });
+  if (!res.ok) throw new Error("Password update failed");
+  return res.json();
 }
 
 export interface PriceItem {
-  _id?: string
-  code?: string
-  ref?: string
-  description: string
-  category?: string
-  subCategory?: string
-  unit?: string
-  rate?: number
-  keywords?: string[]
-  phrases?: string[]
+  _id?: string;
+  code?: string;
+  ref?: string;
+  description: string;
+  category?: string;
+  subCategory?: string;
+  unit?: string;
+  rate?: number;
+  keywords?: string[];
+  phrases?: string[];
 }
 
-export async function searchPriceItems(query: string, token: string): Promise<PriceItem[]> {
-  const url = `${base}/api/prices/search?q=${encodeURIComponent(query)}`
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } })
-  if (!res.ok) throw new Error('Search failed')
-  return res.json()
+export async function searchPriceItems(
+  query: string,
+  token: string,
+): Promise<PriceItem[]> {
+  const url = `${base}/api/prices/search?q=${encodeURIComponent(query)}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error("Search failed");
+  return res.json();
 }
 
 export interface PaginatedResult<T> {
-  items: T[]
-  total: number
+  items: T[];
+  total: number;
 }
 
 export async function getPriceItems(
   token: string,
-  opts: { page?: number; limit?: number; sort?: string; q?: string } = {}
+  opts: { page?: number; limit?: number; sort?: string; q?: string } = {},
 ): Promise<PaginatedResult<PriceItem>> {
-  const params = new URLSearchParams()
-  if (opts.page) params.append('page', String(opts.page))
-  if (opts.limit) params.append('limit', String(opts.limit))
-  if (opts.sort) params.append('sort', opts.sort)
-  if (opts.q) params.append('q', opts.q)
+  const params = new URLSearchParams();
+  if (opts.page) params.append("page", String(opts.page));
+  if (opts.limit) params.append("limit", String(opts.limit));
+  if (opts.sort) params.append("sort", opts.sort);
+  if (opts.q) params.append("q", opts.q);
   const res = await fetch(`${base}/api/prices?${params.toString()}`, {
     headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error('Failed to fetch prices')
-  return res.json()
+  });
+  if (!res.ok) throw new Error("Failed to fetch prices");
+  return res.json();
 }
 
-export async function updatePriceItem(id: string, updates: Partial<PriceItem>, token: string): Promise<PriceItem> {
+export async function updatePriceItem(
+  id: string,
+  updates: Partial<PriceItem>,
+  token: string,
+): Promise<PriceItem> {
   const res = await fetch(`${base}/api/prices/${id}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
     body: JSON.stringify(updates),
-  })
-  if (!res.ok) throw new Error('Update failed')
-  return res.json()
+  });
+  if (!res.ok) throw new Error("Update failed");
+  return res.json();
 }
 
-export async function createPriceItem(item: PriceItem, token: string): Promise<PriceItem> {
+export async function createPriceItem(
+  item: PriceItem,
+  token: string,
+): Promise<PriceItem> {
   const res = await fetch(`${base}/api/prices`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
     body: JSON.stringify(item),
-  })
-  if (!res.ok) throw new Error('Create failed')
-  return res.json()
+  });
+  if (!res.ok) throw new Error("Create failed");
+  return res.json();
 }
 
-export async function deletePriceItem(id: string, token: string): Promise<void> {
+export async function deletePriceItem(
+  id: string,
+  token: string,
+): Promise<void> {
   const res = await fetch(`${base}/api/prices/${id}`, {
-    method: 'DELETE',
+    method: "DELETE",
     headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error('Delete failed')
+  });
+  if (!res.ok) throw new Error("Delete failed");
 }


### PR DESCRIPTION
## Summary
- add nanoid-based async job API on backend
- allow polling async price match jobs
- update client API for async support

## Testing
- `npm --prefix backend test` *(fails: ERR_MODULE_NOT_FOUND)*
- `npm --prefix client test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6849e4ff8c908325a5b8921a41167767