### PR TITLE
Refactor quotation flow and drop project API

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,7 +7,6 @@ import connect from './config/db.js'; // async connection function
 await connect();
 
 import authRoutes from './routes/auth.routes.js';
-import projectRoutes from './routes/project.routes.js';
 import boqRoutes from './routes/boq.routes.js';
 import matchRoutes from './routes/match.routes.js';
 import priceRoutes from './routes/price.routes.js';
@@ -29,7 +28,6 @@ app.get('/', (req, res) => {
 
 // ✅ API Routes
 app.use('/api/auth', authRoutes);
-app.use('/api/projects', auth, projectRoutes);
 app.use('/api/boq', auth, boqRoutes);
 app.use('/api/match', auth, matchRoutes);
 app.use('/api/prices', auth, priceRoutes);

--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -270,6 +270,15 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
   })
 
   const [autoQuoteId, setAutoQuoteId] = useState<string | null>(null)
+  const saveTimer = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    if (!autoQuoteId || !results) return
+    if (saveTimer.current) clearTimeout(saveTimer.current)
+    saveTimer.current = setTimeout(() => {
+      saveQuotationData(results, autoQuoteId)
+    }, 1000)
+  }, [results, discount, autoQuoteId])
 
   const saveQuotationData = async (rows: Row[], id?: string) => {
     const items = rows.map((r, idx) => {

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,23 +1,4 @@
-export interface Project {
-  id: string;
-  client: string;
-  type: string;
-  due: string;
-  status: string;
-  value?: number;
-}
-
 const base = process.env.NEXT_PUBLIC_API_URL ?? "";
-
-export async function getProjects(token: string): Promise<Project[]> {
-  const res = await fetch(`${base}/api/projects`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) {
-    throw new Error(`Failed to fetch projects: ${res.status}`);
-  }
-  return res.json();
-}
 
 export async function loginUser(email: string, password: string) {
   const res = await fetch(`${base}/api/auth/login`, {

--- a/client/lib/quotation-store.ts
+++ b/client/lib/quotation-store.ts
@@ -18,10 +18,11 @@ export interface Quotation {
 }
 
 const KEY = 'quotations'
+const base = process.env.NEXT_PUBLIC_API_URL ?? ''
 
 export async function loadQuotations(): Promise<Quotation[]> {
   try {
-    const res = await fetch('/api/quotations', { cache: 'no-store' })
+    const res = await fetch(`${base}/api/quotations`, { cache: 'no-store' })
     if (res.ok) return (await res.json()) as Quotation[]
   } catch {
     // ignore network errors
@@ -37,7 +38,7 @@ export async function loadQuotations(): Promise<Quotation[]> {
 
 export async function saveQuotation(q: Quotation) {
   try {
-    await fetch('/api/quotations', {
+    await fetch(`${base}/api/quotations`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(q),
@@ -55,7 +56,7 @@ export async function saveQuotation(q: Quotation) {
 
 export async function getQuotation(id: string): Promise<Quotation | undefined> {
   try {
-    const res = await fetch(`/api/quotations/${id}`, { cache: 'no-store' })
+    const res = await fetch(`${base}/api/quotations/${id}`, { cache: 'no-store' })
     if (res.ok) return (await res.json()) as Quotation
   } catch {
     // ignore


### PR DESCRIPTION
## Summary
- drop project route from the backend app
- remove unused project API helpers
- add API base URL to quotation store
- automatically persist quotation updates from price match

## Testing
- `npm test` *(fails: cannot find package 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_684b06a954208325a45f1b43fb909601