### PR TITLE
Enable deletion of quotations

### DIFF
--- a/backend/src/routes/quotation.routes.js
+++ b/backend/src/routes/quotation.routes.js
@@ -47,4 +47,19 @@ router.post('/', async (req, res) => {
   res.status(201).json(data);
 });
 
+router.delete('/:id', async (req, res) => {
+  const { id } = req.params;
+
+  if (process.env.CONNECTION_STRING) {
+    const doc = await Quotation.findOneAndDelete({ id });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    return res.json({ message: 'deleted' });
+  }
+
+  const idx = sampleQuotations.findIndex(q => q.id === id);
+  if (idx === -1) return res.status(404).json({ message: 'Not found' });
+  sampleQuotations.splice(idx, 1);
+  res.json({ message: 'deleted' });
+});
+
 export default router;

--- a/client/components/quotation-grid.tsx
+++ b/client/components/quotation-grid.tsx
@@ -6,11 +6,11 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Eye, Edit, Download, Filter, Search } from "lucide-react"
+import { Eye, Edit, Download, Filter, Search, Trash } from "lucide-react"
 import Link from "next/link"
 import { useMobileOptimization } from "@/components/mobile-optimization-provider"
 import { cn, formatCurrency, formatDate } from "@/lib/utils"
-import { loadQuotations } from "@/lib/quotation-store"
+import { loadQuotations, deleteQuotation } from "@/lib/quotation-store"
 
 interface Quotation {
   id: string
@@ -95,6 +95,14 @@ export function QuotationGrid() {
         {status.replace("-", " ").toUpperCase()}
       </Badge>
     )
+  }
+
+  const handleDelete = async (id: string) => {
+    const confirm = window.confirm('Delete this quotation?')
+    if (!confirm) return
+    await deleteQuotation(id)
+    setQuotations(prev => prev.filter(q => q.id !== id))
+    setVisibleQuotations(prev => prev.filter(q => q.id !== id))
   }
 
   return (
@@ -234,6 +242,14 @@ export function QuotationGrid() {
                         className="border-white/20 hover:bg-white/10 ripple mobile-touch"
                       >
                         <Download className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleDelete(quotation.id)}
+                        className="border-red-500/30 text-red-500 hover:bg-red-500/20 ripple mobile-touch"
+                      >
+                        <Trash className="h-4 w-4" />
                       </Button>
                     </div>
                   </CardContent>

--- a/client/lib/quotation-store.ts
+++ b/client/lib/quotation-store.ts
@@ -81,3 +81,15 @@ export async function getQuotation(id: string): Promise<Quotation | undefined> {
   return all.find(q => q.id === id)
 }
 
+export async function deleteQuotation(id: string) {
+  try {
+    await fetch(`${base}/api/quotations/${id}`, { method: 'DELETE' })
+  } catch {
+    // ignore
+  }
+  if (typeof localStorage === 'undefined') return
+  const all = await loadQuotations()
+  const updated = all.filter(q => q.id !== id)
+  localStorage.setItem(KEY, JSON.stringify(updated))
+}
+


### PR DESCRIPTION
## Summary
- support DELETE /api/quotations/:id in backend
- add deleteQuotation helper on the frontend
- allow deleting a quotation from the grid view

## Testing
- `npm test` *(fails: ERR_ASSERTION)*

------
https://chatgpt.com/codex/tasks/task_b_684b45ba47e88325b2456124e5bae6c2