### PR TITLE
Add searchText field to PriceItem

### DIFF
--- a/backend/scripts/importPriceList.js
+++ b/backend/scripts/importPriceList.js
@@ -74,6 +74,15 @@ async function main() {
               .filter(Boolean)
           : undefined,
     };
+    item.searchText = [
+      item.description,
+      item.category,
+      item.subCategory,
+      ...(item.keywords || []),
+      ...(item.phrases || [])
+    ]
+      .filter(Boolean)
+      .join(' ');
     items.push(item);
   }
 

--- a/backend/src/models/PriceItem.js
+++ b/backend/src/models/PriceItem.js
@@ -11,8 +11,36 @@ const priceItemSchema = new mongoose.Schema(
     rate: { type: Number },
     keywords: [String],
     phrases: [String],
+    searchText: { type: String },
   },
   { timestamps: true }
 );
+
+function buildSearchText(doc) {
+  const parts = [
+    doc.description,
+    doc.category,
+    doc.subCategory,
+    ...(doc.keywords || []),
+    ...(doc.phrases || [])
+  ];
+  return parts.filter(Boolean).join(' ');
+}
+
+priceItemSchema.pre('save', function (next) {
+  this.searchText = buildSearchText(this);
+  next();
+});
+
+priceItemSchema.pre('findOneAndUpdate', async function (next) {
+  let update = this.getUpdate() || {};
+  const doc = await this.model.findOne(this.getQuery()).lean();
+  if (doc) {
+    const merged = { ...doc, ...update.$set, ...update };
+    update.$set = { ...(update.$set || {}), searchText: buildSearchText(merged) };
+    this.setUpdate(update);
+  }
+  next();
+});
 
 export default mongoose.model('PriceItem', priceItemSchema);

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -108,6 +108,7 @@ export interface PriceItem {
   rate?: number;
   keywords?: string[];
   phrases?: string[];
+  searchText?: string;
 }
 
 export async function searchPriceItems(


### PR DESCRIPTION
## Summary
- add `searchText` to `PriceItem` model and auto-populate with combined text
- compute `searchText` when importing price list
- include `searchText` when creating/updating items via API
- expose new field in client API types

## Testing
- `npm test --prefix backend` *(fails: cannot find module 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_684b4a5433c483258ecff646367226d4