### PR TITLE
Improve pricing filters and quotation actions

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -16,14 +16,14 @@ const inter = Inter({
 })
 
 export const metadata: Metadata = {
-  title: "MJD Construction - Quotation Management Platform",
-  description: "Premium quotation management for MJD Construction Engineering",
+  title: "BOQ Pricing Pro",
+  description: "Premium quotation management for construction projects",
   manifest: "/manifest.json",
   themeColor: "#000000",
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
-    title: "MJD Construction",
+    title: "BOQ Pricing Pro",
   },
   formatDetection: {
     telephone: true,

--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -409,18 +409,15 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
               onChange={e => setClientName(e.target.value)}
               className="bg-gray-800/20 border-white/10"
             />
-            <div className="space-y-1">
-              <span className="text-white text-sm">Version</span>
-              <Select value={version} onValueChange={val => setVersion(val as 'v0' | 'v1')}>
-                <SelectTrigger className="w-24 bg-gray-800/20 border-white/10">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="v0">v0</SelectItem>
-                  <SelectItem value="v1">v1</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            <Select value={version} onValueChange={val => setVersion(val as 'v0' | 'v1')}>
+              <SelectTrigger className="w-24 bg-gray-800/20 border-white/10">
+                <SelectValue placeholder="Version" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="v0">v0</SelectItem>
+                <SelectItem value="v1">v1</SelectItem>
+              </SelectContent>
+            </Select>
             <Input
               type="file"
               accept=".xlsx,.xls"

--- a/client/components/quotation-grid.tsx
+++ b/client/components/quotation-grid.tsx
@@ -229,20 +229,24 @@ export function QuotationGrid() {
                           View
                         </Button>
                       </Link>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="border-white/20 hover:bg-white/10 ripple mobile-touch"
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="border-white/20 hover:bg-white/10 ripple mobile-touch"
-                      >
-                        <Download className="h-4 w-4" />
-                      </Button>
+                      <Link href={`/quotations/${quotation.id}?edit=true`}>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="border-white/20 hover:bg-white/10 ripple mobile-touch"
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                      </Link>
+                      <Link href={`/quotations/${quotation.id}?download=true`}>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="border-white/20 hover:bg-white/10 ripple mobile-touch"
+                        >
+                          <Download className="h-4 w-4" />
+                        </Button>
+                      </Link>
                       <Button
                         size="sm"
                         variant="outline"

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -130,13 +130,16 @@ export interface PaginatedResult<T> {
 
 export async function getPriceItems(
   token: string,
-  opts: { page?: number; limit?: number; sort?: string; q?: string } = {},
+  opts: { page?: number; limit?: number; sort?: string; q?: string; categories?: string[] } = {},
 ): Promise<PaginatedResult<PriceItem>> {
   const params = new URLSearchParams();
   if (opts.page) params.append("page", String(opts.page));
   if (opts.limit) params.append("limit", String(opts.limit));
   if (opts.sort) params.append("sort", opts.sort);
   if (opts.q) params.append("q", opts.q);
+  if (opts.categories && opts.categories.length) {
+    params.append('categories', opts.categories.join(','));
+  }
   const res = await fetch(`${base}/api/prices?${params.toString()}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -186,4 +189,12 @@ export async function deletePriceItem(
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error("Delete failed");
+}
+
+export async function getCategories(token: string): Promise<string[]> {
+  const res = await fetch(`${base}/api/prices/categories/list`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to fetch categories');
+  return res.json();
 }

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "MJD Construction - Quotation Management",
-  "short_name": "MJD Quotes",
-  "description": "Premium quotation management for construction engineering",
+  "name": "BOQ Pricing Pro",
+  "short_name": "BOQ Pricing",
+  "description": "Premium quotation management for construction projects",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#000000",


### PR DESCRIPTION
## Summary
- add category filters to price list and fetch categories from API
- expose categories list endpoint and support filtering by multiple categories
- adjust price match UI for version selector
- enable editing and downloading from quotation cards
- auto-start edit/download modes in quotation page and allow Excel export
- remove save-all button in price list
- rename app to **BOQ Pricing Pro**

## Testing
- `npm test --prefix backend` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_b_684b4d9ede188325a09dfa439de99c6b