### PR TITLE
Add fullContext field to price items

### DIFF
--- a/backend/scripts/importPriceList.js
+++ b/backend/scripts/importPriceList.js
@@ -5,6 +5,20 @@ import PriceItem from '../src/models/PriceItem.js';
 
 dotenv.config();
 
+function buildFullContext(d) {
+  return [
+    `Description: ${d.description || ''}`,
+    `Keywords: ${(d.keywords || []).join(', ')}`,
+    `Phrases: ${(d.phrases || []).join(', ')}`,
+    `Code: ${d.code || ''}`,
+    `Category: ${d.category || ''}`,
+    `SubCategory: ${d.subCategory || ''}`,
+    `Unit: ${d.unit || ''}`,
+    `Rate: ${d.rate ?? ''}`,
+    `Ref: ${d.ref || ''}`
+  ].join(' | ');
+}
+
 async function main() {
   const conn = process.env.CONNECTION_STRING;
   if (!conn) {
@@ -83,6 +97,7 @@ async function main() {
     ]
       .filter(Boolean)
       .join(' ');
+    item.fullContext = buildFullContext(item);
     items.push(item);
   }
 

--- a/backend/src/routes/price.routes.js
+++ b/backend/src/routes/price.routes.js
@@ -3,6 +3,20 @@ import PriceItem from '../models/PriceItem.js';
 
 const router = Router();
 
+function buildFullContext(d) {
+  return [
+    `Description: ${d.description || ''}`,
+    `Keywords: ${(d.keywords || []).join(', ')}`,
+    `Phrases: ${(d.phrases || []).join(', ')}`,
+    `Code: ${d.code || ''}`,
+    `Category: ${d.category || ''}`,
+    `SubCategory: ${d.subCategory || ''}`,
+    `Unit: ${d.unit || ''}`,
+    `Rate: ${d.rate ?? ''}`,
+    `Ref: ${d.ref || ''}`
+  ].join(' | ');
+}
+
 // List price items with pagination, sorting and optional search
 router.get('/', async (req, res) => {
   const page = Math.max(parseInt(req.query.page) || 1, 1);
@@ -88,6 +102,7 @@ router.post('/', async (req, res) => {
     ]
       .filter(Boolean)
       .join(' ');
+    data.fullContext = buildFullContext(data);
     const doc = await PriceItem.create(data);
     res.status(201).json(doc);
   } catch (err) {
@@ -111,9 +126,10 @@ router.patch('/:id', async (req, res) => {
     ]
       .filter(Boolean)
       .join(' ');
+    const fullContext = buildFullContext(data);
     const doc = await PriceItem.findByIdAndUpdate(
       id,
-      { ...req.body, searchText },
+      { ...req.body, searchText, fullContext },
       { new: true }
     );
     if (!doc) return res.status(404).json({ message: 'Not found' });

--- a/backend/src/services/coherepricematcher.py
+++ b/backend/src/services/coherepricematcher.py
@@ -207,8 +207,8 @@ def load_pricelist_from_db(logger_fn):
     col = db["priceitems"]
     descriptions = []
     rates = []
-    for doc in col.find({"rate": {"$ne": None}, "unit": {"$exists": True, "$ne": ""}}, {"description":1, "rate":1}):
-        desc = doc.get("description")
+    for doc in col.find({"rate": {"$ne": None}, "unit": {"$exists": True, "$ne": ""}}, {"fullContext":1, "rate":1}):
+        desc = doc.get("fullContext")
         rate = doc.get("rate")
         if desc and rate is not None:
             descriptions.append(preprocess_text(desc))

--- a/backend/src/services/openaipricematcher.py
+++ b/backend/src/services/openaipricematcher.py
@@ -207,8 +207,8 @@ def load_pricelist_from_db(logger_fn):
     col = db["priceitems"]
     descriptions = []
     rates = []
-    for doc in col.find({"rate": {"$ne": None}, "unit": {"$exists": True, "$ne": ""}}, {"description":1, "rate":1}):
-        desc = doc.get("description")
+    for doc in col.find({"rate": {"$ne": None}, "unit": {"$exists": True, "$ne": ""}}, {"fullContext":1, "rate":1}):
+        desc = doc.get("fullContext")
         rate = doc.get("rate")
         if desc and rate is not None:
             descriptions.append(preprocess_text(desc))


### PR DESCRIPTION
## Summary
- extend `PriceItem` schema with `fullContext`
- generate `fullContext` on create/update and during price list import
- update routes to return new field
- use `fullContext` for DB lookups in price matcher utilities

## Testing
- `npm test --prefix backend` *(fails: cannot find input files)*

------
https://chatgpt.com/codex/tasks/task_b_684b507b0ff083259c5515bc5b676a09