### PR TITLE
Improve price-match loading progress

### DIFF
--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -109,10 +109,19 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
   useEffect(() => {
     let interval: NodeJS.Timeout | null = null
     if (loading) {
+      setProgress(0)
+      setTextIndex(0)
       interval = setInterval(() => {
-        setProgress(p => (p >= 100 ? 0 : p + 5))
+        setProgress(p => {
+          const next = p + 1
+          if (next >= 100) {
+            if (interval) clearInterval(interval)
+            return 100
+          }
+          return next
+        })
         setTextIndex(i => (i + 1) % texts.length)
-      }, 500)
+      }, 1000)
     } else {
       setProgress(0)
     }


### PR DESCRIPTION
## Summary
- show a 100 second progress animation when starting matching

## Testing
- `npm install` *(fails: 2 vulnerabilities)*
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_b_684b522350ac8325a5071854f972bf50