### PR TITLE
Add Cohere-based price matcher v2

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -10,6 +10,8 @@ import {
 import {
   cohereMatchFromFiles,
   cohereMatchFromDb,
+  cohereMatchFromFilesV2,
+  cohereMatchFromDbV2,
 } from "../services/cohereService.js";
 import { matchFromFiles } from "../services/matchService.js";
 import { fileURLToPath } from "url";
@@ -76,7 +78,16 @@ router.post("/", upload.single("file"), async (req, res) => {
   const run = async () => {
     let results;
     const useDb = !!process.env.CONNECTION_STRING;
-    if (version === 'v1') {
+    if (version === 'v2') {
+      if (cohereKey) {
+        console.log('Calling Cohere v2 matcher');
+        results = await (useDb
+          ? cohereMatchFromDbV2(req.file.buffer, cohereKey)
+          : cohereMatchFromFilesV2(PRICE_FILE, req.file.buffer, cohereKey));
+      } else {
+        results = matchFromFiles(PRICE_FILE, req.file.buffer);
+      }
+    } else if (version === 'v1') {
       if (cohereKey) {
         console.log('Calling Cohere matcher');
         results = await (useDb

--- a/backend/src/services/cohereService.js
+++ b/backend/src/services/cohereService.js
@@ -8,6 +8,8 @@ import PriceItem from '../models/PriceItem.js';
 const EMBEDDING_MODEL = process.env.COHERE_EMBEDDING_MODEL || 'embed-english-v3.0';
 const BATCH_SIZE = 96;
 const API_URL = 'https://api.cohere.ai/v1/embed';
+const FUZZY_THRESHOLD = 0.4;
+const FALLBACK_CANDIDATES = 5;
 
 async function loadPriceItemsFromDb() {
   const docs = await PriceItem.find({
@@ -23,8 +25,29 @@ async function loadPriceItemsFromDb() {
   }));
 }
 
+async function loadPriceItemsFromDbV2() {
+  const docs = await PriceItem.find({
+    rate: { $ne: null },
+    unit: { $exists: true, $ne: '' }
+  }).lean();
+  return docs.map(d => ({
+    code: d.code || '',
+    description: d.description,
+    unit: d.unit || '',
+    rate: d.rate,
+    category: d.category || '',
+    subCategory: d.subCategory || '',
+    text: preprocessV2(d.fullContext || ''),
+    simpleDesc: d.description || ''
+  }));
+}
+
 function buildTexts(items) {
   return items.map(p => p.descClean);
+}
+
+function buildTextsV2(items) {
+  return items.map(p => p.text);
 }
 
 function dot(a, b) {
@@ -44,6 +67,49 @@ function normalize(vecs) {
     const n = l2Norm(v) || 1;
     return v.map(x => x / n);
   });
+}
+
+// --- v2 helpers ---
+function preprocessV2(text) {
+  if (!text) return '';
+  return String(text)
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/mm\./g, 'mm')
+    .replace(/cm\./g, 'cm')
+    .replace(/r\.c\.c\./g, 'rcc')
+    .replace(/reinforced cement concrete/g, 'rcc')
+    .trim();
+}
+
+function levenshtein(a, b) {
+  const m = a.length;
+  const n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return dp[m][n];
+}
+
+function ratio(a, b) {
+  if (!a && !b) return 1;
+  const dist = levenshtein(a, b);
+  return 1 - dist / Math.max(a.length, b.length, 1);
+}
+
+function tokenSortRatio(a, b) {
+  const sortTokens = s => s.split(/\s+/).filter(Boolean).sort().join(' ');
+  return ratio(sortTokens(a), sortTokens(b));
 }
 
 async function fetchEmbeddings(apiKey, texts, inputType) {
@@ -142,3 +208,97 @@ export async function cohereMatchFromDb(inputBuffer, apiKey) {
   console.log('Price items:', priceItems.length, 'Input items:', inputItems.length);
   return cohereMatch(priceItems, inputItems, apiKey);
 }
+
+// ----- Version 2 matching -----
+export async function cohereMatchFromFilesV2(priceFile, inputBuffer, apiKey) {
+  console.log('Cohere v2 matcher loading files');
+  const priceItems = loadPriceList(priceFile).map(p => ({
+    ...p,
+    text: preprocessV2(
+      `Description: ${p.description || ''} | Code: ${p.code || ''} | Unit: ${p.unit || ''} | Rate: ${p.rate ?? ''}`
+    ),
+    simpleDesc: p.description || ''
+  }));
+  const inputRaw = parseInputBuffer(inputBuffer);
+  const inputItems = inputRaw.map(it => ({
+    description: it.description,
+    qty: it.qty,
+    text: preprocessV2(it.description)
+  }));
+  console.log('Price items:', priceItems.length, 'Input items:', inputItems.length);
+  return cohereMatchV2(priceItems, inputItems, apiKey);
+}
+
+export async function cohereMatchFromDbV2(inputBuffer, apiKey) {
+  console.log('Cohere v2 matcher loading from DB');
+  const priceItems = await loadPriceItemsFromDbV2();
+  const inputRaw = parseInputBuffer(inputBuffer);
+  const inputItems = inputRaw.map(it => ({
+    description: it.description,
+    qty: it.qty,
+    text: preprocessV2(it.description)
+  }));
+  console.log('Price items:', priceItems.length, 'Input items:', inputItems.length);
+  return cohereMatchV2(priceItems, inputItems, apiKey);
+}
+
+async function cohereMatchV2(priceItems, inputItems, apiKey) {
+  const priceTexts = buildTextsV2(priceItems);
+  const inputTexts = buildTextsV2(inputItems);
+
+  console.log('Fetching embeddings for price list');
+  const priceEmbeds = await fetchEmbeddings(apiKey, priceTexts, 'search_document');
+  console.log('Fetching embeddings for input items');
+  const inputEmbeds = await fetchEmbeddings(apiKey, inputTexts, 'search_query');
+
+  const normPrice = normalize(priceEmbeds);
+  const normInput = normalize(inputEmbeds);
+
+  console.log('Calculating similarities');
+  return inputItems.map((it, idx) => {
+      const sims = normPrice.map(vec => dot(normInput[idx], vec));
+      let bestIdx = 0;
+      let bestScore = sims[0];
+      for (let j = 1; j < sims.length; j++) {
+        if (sims[j] > bestScore) {
+          bestScore = sims[j];
+          bestIdx = j;
+        }
+      }
+      if (bestScore < FUZZY_THRESHOLD) {
+        const top = sims
+          .map((s, j) => ({ s, j }))
+          .sort((a, b) => b.s - a.s)
+          .slice(0, FALLBACK_CANDIDATES);
+        let comboIdx = bestIdx;
+        let comboScore = bestScore;
+        for (const cand of top) {
+          const fuzzy = tokenSortRatio(it.text, priceItems[cand.j].simpleDesc.toLowerCase());
+          const combined = 0.7 * cand.s + 0.3 * fuzzy;
+          if (combined > comboScore) {
+            comboScore = combined;
+            comboIdx = cand.j;
+          }
+        }
+        bestIdx = comboIdx;
+        bestScore = comboScore;
+      }
+      const best = priceItems[bestIdx];
+      return {
+        inputDescription: it.description,
+        quantity: it.qty,
+        engine: 'cohere',
+        matches: [
+          {
+            engine: 'cohere',
+            code: best.code,
+            description: `${best.description} (cohere)`,
+            unit: best.unit,
+            unitRate: best.rate,
+            confidence: Math.round(bestScore * 1000) / 1000
+          }
+        ]
+      };
+  });
+}
+

--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -59,7 +59,7 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
   const [discount, setDiscount] = useState(0)
   const [projectName, setProjectName] = useState("")
   const [clientName, setClientName] = useState("")
-  const [version, setVersion] = useState<'v0' | 'v1'>('v0')
+  const [version, setVersion] = useState<'v0' | 'v1' | 'v2'>('v0')
   const [page, setPage] = useState(0)
   const pageSize = 100
   const [inputsCollapsed, setInputsCollapsed] = useState(false)
@@ -418,13 +418,14 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
               onChange={e => setClientName(e.target.value)}
               className="bg-gray-800/20 border-white/10"
             />
-            <Select value={version} onValueChange={val => setVersion(val as 'v0' | 'v1')}>
+            <Select value={version} onValueChange={val => setVersion(val as 'v0' | 'v1' | 'v2')}>
               <SelectTrigger className="w-24 bg-gray-800/20 border-white/10">
                 <SelectValue placeholder="Version" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="v0">v0</SelectItem>
                 <SelectItem value="v1">v1</SelectItem>
+                <SelectItem value="v2">v2</SelectItem>
               </SelectContent>
             </Select>
             <Input

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -33,7 +33,7 @@ export async function priceMatch(
   file: File,
   keys: { openaiKey?: string; cohereKey?: string; geminiKey?: string },
   token: string,
-  version: 'v0' | 'v1',
+  version: 'v0' | 'v1' | 'v2',
   asyncMode = false,
 ) {
   const form = new FormData();


### PR DESCRIPTION
## Summary
- implement new Cohere matching algorithm with fuzzy fallback
- expose v2 matching endpoints on the backend
- support v2 selection in the frontend

## Testing
- `npm test --prefix backend` *(fails: Error: module not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b586d49048325ae5197f88650c8ac