### PR TITLE
Update docs for v2 script path

### DIFF
--- a/pricematch/README.md
+++ b/pricematch/README.md
@@ -4,6 +4,6 @@ This folder contains standalone scripts for matching price list items to inquiry
 
 - **v0** – Uses both OpenAI and Cohere APIs. Includes `openaipricematcher.py` and `coherepricematcher.py`.
 - **v1** – Uses only Cohere via `coherepricematcher.py`.
-- **v2** – Adds fuzzy fallback and optional taxonomy columns in `coherepricematcher.py`.
+- **v2** – Adds fuzzy fallback and optional taxonomy columns. Run `python pricematch/v2/coherepricematcher.py` to launch.
 
 Each script provides a simple Tkinter interface to load the inquiry Excel file and output the priced result.

--- a/pricematch/v2/README.md
+++ b/pricematch/v2/README.md
@@ -2,5 +2,5 @@
 
 Version 2 expands the matching logic with Cohere's Embed v4 API. It adds
 optional fuzzy text fallback and can copy Category/SubCategory columns when
-available. Run `coherepricematcher.py` to select your files and process the
-spreadsheet.
+available. Run `python pricematch/v2/coherepricematcher.py` to select your files
+and process the spreadsheet.


### PR DESCRIPTION
## Summary
- clarify that Price Match v2 should be launched via `python pricematch/v2/coherepricematcher.py`

## Testing
- `npm test --prefix backend` *(fails: Cannot find package 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_b_684b5c76990c83258b5a6d3416d657fa